### PR TITLE
Add support for intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Code is based on https://gitlab.com/a/dpybotbase and https://github.com/916253/K
 ## How to run
 
 - Copy `config.py.template` to `config.py`, configure all necessary parts to your server.
+- Enable the `Server Members` privileged intent ([guide here](https://discordpy.readthedocs.io/en/latest/intents.html?highlight=intents#privileged-intents)) for the bot. You don't need to give Discord your passport as Robocop-NG is not designed to run at >1 guild at once, let alone >100.
 - (obviously) Add the bot to your guild. Many resources about this online.
 - If you haven't already done this already, **move the bot's role above the roles it'll need to manage, or else it won't function properly**, this is especially important for verification as it doesn't work otherwise.
 - Install python3.6+.

--- a/Robocop.py
+++ b/Robocop.py
@@ -226,4 +226,8 @@ for wanted_json in wanted_jsons:
         with open(wanted_json, "w") as f:
             f.write("{}")
 
-bot.run(config.token, bot=True, reconnect=True)
+intents = discord.Intents.default()
+intents.typing = False
+intents.members = True
+
+bot.run(config.token, bot=True, reconnect=True, intents=intents)

--- a/Robocop.py
+++ b/Robocop.py
@@ -46,7 +46,11 @@ wanted_jsons = [
     "data/invites.json",
 ]
 
-bot = commands.Bot(command_prefix=get_prefix, description=config.bot_description)
+intents = discord.Intents.default()
+intents.typing = False
+intents.members = True
+
+bot = commands.Bot(command_prefix=get_prefix, description=config.bot_description, intents=intents)
 bot.help_command = commands.DefaultHelpCommand(dm_help=True)
 
 bot.log = log
@@ -226,8 +230,4 @@ for wanted_json in wanted_jsons:
         with open(wanted_json, "w") as f:
             f.write("{}")
 
-intents = discord.Intents.default()
-intents.typing = False
-intents.members = True
-
-bot.run(config.token, bot=True, reconnect=True, intents=intents)
+bot.run(config.token, bot=True, reconnect=True)

--- a/cogs/mod_userlog.py
+++ b/cogs/mod_userlog.py
@@ -230,7 +230,6 @@ class ModUserlog(Cog):
             f"created_at = {user.created_at}\n"
             f"display_name = {display_name}\n"
             f"joined_at = {user.joined_at}\n"
-            f"activities = `{user.activities}`\n"
             f"color = {user.colour}\n"
             f"top_role = {role}\n",
             embed=embed,

--- a/cogs/ryujinx_verification.py
+++ b/cogs/ryujinx_verification.py
@@ -1,0 +1,94 @@
+import discord
+from discord.ext import commands
+from discord.ext.commands import Cog
+import config
+import random
+from helpers.checks import check_if_staff
+
+
+class RyujinxVerification(Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+        # Export reset channel functions
+        self.bot.do_reset = self.do_reset
+        self.bot.do_resetalgo = self.do_resetalgo
+
+    @Cog.listener()
+    async def on_member_join(self, member):
+        await self.bot.wait_until_ready()
+
+        if (member.guild.id not in config.guild_whitelist):
+            return
+
+        join_channel = self.bot.get_channel(config.welcome_channel)
+
+        if join_channel is not None:
+            await join_channel.send('Hello {0.mention}! Welcome to Ryujinx! Please read the <#411271165429022730>, and then type the verifying command here to gain access to the rest of the channels.\n\nIf you need help with basic common questions, visit the <#585288848704143371> channel after joining.\n\nIf you need help with Animal Crossing visit the <#692104087889641472> channel for common issues and solutions. If you need help that is not Animal Crossing related, please visit the <#410208610455519243> channel after verifying.'.format(member))
+
+    async def process_message(self, message):
+        """Process the verification process"""
+        if message.channel.id == config.welcome_channel:
+            # Assign common stuff into variables to make stuff less of a mess
+            mcl = message.content.lower()
+
+            # Get the role we will give in case of success
+            success_role = message.guild.get_role(config.participant_role)
+
+            if config.verification_string == mcl:
+                await message.author.add_roles(success_role)
+                await message.delete()
+
+    @Cog.listener()
+    async def on_message(self, message):
+        if message.author.bot:
+            return
+
+        try:
+            await self.process_message(message)
+        except discord.errors.Forbidden:
+            chan = self.bot.get_channel(message.channel)
+            await chan.send("💢 I don't have permission to do this.")
+
+    @Cog.listener()
+    async def on_message_edit(self, before, after):
+        if after.author.bot:
+            return
+
+        try:
+            await self.process_message(after)
+        except discord.errors.Forbidden:
+            chan = self.bot.get_channel(after.channel)
+            await chan.send("💢 I don't have permission to do this.")
+
+    @Cog.listener()
+    async def on_member_join(self, member):
+        await self.bot.wait_until_ready()
+
+        if (member.guild.id not in config.guild_whitelist):
+            return
+
+        join_channel = self.bot.get_channel(config.welcome_channel)
+
+        if join_channel is not None:
+            await join_channel.send(config.join_message.format(member))
+
+    @commands.check(check_if_staff)
+    @commands.command()
+    async def reset(self, ctx, limit: int = 100, force: bool = False):
+        """Wipes messages and pastes the welcome message again. Staff only."""
+        if ctx.message.channel.id != config.welcome_channel and not force:
+            await ctx.send(f"This command is limited to"
+                           f" <#{config.welcome_channel}>, unless forced.")
+            return
+        await self.do_reset(ctx.channel, ctx.author.mention, limit)
+
+    async def do_reset(self, channel, author, limit: int = 100):
+        await channel.purge(limit=limit)
+
+    async def do_resetalgo(self, channel, author, limit: int = 100):
+        # We only auto clear the channel daily
+        await self.do_reset(channel, author)
+
+def setup(bot):
+    bot.add_cog(RyujinxVerification(bot))

--- a/config_template.py
+++ b/config_template.py
@@ -50,6 +50,10 @@ initial_cogs = [
 # and sends pins above limit to a github gist
 
 
+# The string that users need to say to get past verification
+verification_string = "go read the rules, not the code"
+
+
 # Minimum account age required to join the guild
 # If user's account creation is shorter than the time delta given here
 # then user will be kicked and informed


### PR DESCRIPTION
This PR adds support for intents, enables "Server Members" Privileged Intent, and drops requirement of "Presence" Privileged Intent. This is needed to keep role-based actions (which is a lot for a moderation bot) running.

- You will need to update to discord.py 1.5.0 or higher (`pip3 install -U discord.py`)
- You will need to enable the "Server Members" privileged intent: https://discordpy.readthedocs.io/en/latest/intents.html?highlight=intents#privileged-intents

This is a little urgent as discord will be changing default intents on [October 7, 2020](https://support.discord.com/hc/en-us/articles/360040720412#privileged-intent-whitelisting). ID verification is not needed as the bot will only be in one server, not 100+. Sorry for being so late about this, but discord.py [only added support this Tuesday with 1.5.0](https://discordpy.readthedocs.io/en/latest/whats_new.html#v1-5-0).