### PR TITLE
Added log reading capabilities to Ryuko bot

### DIFF
--- a/Robocop.py
+++ b/Robocop.py
@@ -8,6 +8,8 @@ import config
 
 import discord
 from discord.ext import commands
+from cogs.logfilereader import LogFileReader
+
 
 script_name = os.path.basename(__file__).split(".")[0]
 
@@ -50,7 +52,9 @@ intents = discord.Intents.default()
 intents.typing = False
 intents.members = True
 
-bot = commands.Bot(command_prefix=get_prefix, description=config.bot_description, intents=intents)
+bot = commands.Bot(
+    command_prefix=get_prefix, description=config.bot_description, intents=intents
+)
 bot.help_command = commands.DefaultHelpCommand(dm_help=True)
 
 bot.log = log
@@ -217,6 +221,15 @@ async def on_message(message):
         cmd in message.content for cmd in welcome_allowed
     ):
         return
+
+    # if message has an attachment
+    try:
+        if message.attachments[0]:
+            # return message so that author and relevant data can be used
+            embed = await LogFileReader.log_file_read(message)
+            return await message.channel.send(embed = embed)
+    except IndexError:
+        pass
 
     ctx = await bot.get_context(message)
     await bot.invoke(ctx)

--- a/Robocop.py
+++ b/Robocop.py
@@ -225,11 +225,15 @@ async def on_message(message):
     # if message has an attachment
     try:
         if message.attachments[0]:
-            # return message so that author and relevant data can be used
-            embed = await LogFileReader.log_file_read(message)
-            return await message.channel.send(embed = embed)
+            reader = LogFileReader(bot)
+            embed = await reader.log_file_read(message)
+            return await message.channel.send(embed=embed)
     except IndexError:
         pass
+    except UnicodeDecodeError:
+        return await message.channel.send(
+            f"This log file appears to be invalid {message.author.mention}. Please re-check and re-upload your log file."
+        )
 
     ctx = await bot.get_context(message)
     await bot.invoke(ctx)

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -1,0 +1,64 @@
+import discord
+import re
+import aiohttp
+
+
+class LogFileReader:
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def download_file(log_url):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(log_url) as response:
+                return await response.text()
+
+    async def log_file_read(message):
+        attached_log = message.attachments[0]
+        filename = attached_log.filename
+        if re.match(r"^Ryujinx_.*\.log$", filename):
+            author = f"@{message.author.name}"
+            log_file = await LogFileReader.download_file(attached_log.url)
+
+            regex_map = {
+                "Ryu_Version": "Ryujinx Version",
+                "Firmware": "Firmware Version",
+                "OS": "Operating System",
+                "CPU": "CPU",
+                "GPU": "PrintGpuInformation",
+                "RAM": "Total RAM",
+                "Game_Name": "Loader LoadNca: Application Loaded",
+            }
+
+            def make_regex_obj(key, value):
+                return re.compile(fr"{value}: (?P<{key}>.*)$", re.MULTILINE)
+
+            def find_specs(body, key, regexobj):
+                match = regexobj.search(body)
+                return match.group(key) if match is not None else None
+
+            def specs_search(body):
+                return {
+                    key: find_specs(body, key, make_regex_obj(key, value))
+                    for key, value in regex_map.items()
+                }
+
+            system_info = specs_search(log_file)
+
+            def generate_log_embed(author_id, log_info):
+                log_embed = discord.Embed(
+                    title=f"{log_info['Game_Name']}", colour=discord.Colour(0x4a90e2)
+                )
+                log_embed.set_footer(text=f"Log uploaded by {author_id}")
+                log_embed.add_field(
+                    name="**Ryujinx Info**",
+                    value=f"**Version:** {log_info['Ryu_Version']}\n**Firmware:** {log_info['Firmware']}",
+                )
+                log_embed.add_field(
+                    name="Hardware Info",
+                    value=f"**CPU:** {log_info['CPU']}\n**GPU:** {log_info['GPU']}\n**RAM:** {log_info['RAM']}",
+                )
+                return log_embed
+
+            print(system_info)
+            # message = f"This is a valid Ryujinx log file. Thanks <@{author}>"
+            return generate_log_embed(author, system_info)

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -1,3 +1,4 @@
+from typing import Type
 import discord
 import re
 import aiohttp
@@ -9,10 +10,10 @@ class LogFileReader:
 
     async def download_file(self, log_url):
         async with aiohttp.ClientSession() as session:
-            # grabs first and last 4kB of log file to prevent abuse from large files
-            headers = {"Range": "bytes=0-6000, -6000"}
+            # grabs first 20kb of log file to account for longer logs and prevent abuse from large files
+            headers = {"Range": "bytes=0-20000, -6000"}
             async with session.get(log_url, headers=headers) as response:
-                return await response.text()
+                return await response.text("UTF-8")
 
     async def log_file_read(self, message):
         attached_log = message.attachments[0]
@@ -48,20 +49,32 @@ class LogFileReader:
                     for key, value in regex_map.items()
                 }
 
-            system_info = specs_search(log_file)
+            def mods_information(log_file):
+                mods_regex = re.compile(r"Found mod\s\'(.+?)\'\s(\[.+?\])")
+                matches = re.findall(mods_regex, log_file)
+                if matches:
+                    mods = [{"mod": match[0], "status": match[1]} for match in matches]
+                    mods_status = [
+                        f"ℹ️ {i['mod']} ({'ExeFS' if i['status'] == '[E]' else 'RomFS'})"
+                        for i in mods
+                    ]
+                    return mods_status
 
             def generate_log_embed(author_id, log_info):
+                cleaned_game_name = re.sub(
+                    r"\s\[(64|32)-bit\]$", "", log_info["Game_Name"]
+                )
                 log_embed = discord.Embed(
-                    title=f"{log_info['Game_Name']}", colour=discord.Colour(0x4A90E2)
+                    title=f"{cleaned_game_name}", colour=discord.Colour(0x4A90E2)
                 )
                 log_embed.set_footer(text=f"Log uploaded by {author_id}")
                 log_embed.add_field(
-                    name="Ryujinx Info",
-                    value=f"**Version:** {log_info['Ryu_Version']}\n**Firmware:** {log_info['Firmware']}",
-                )
-                log_embed.add_field(
                     name="Hardware Info",
                     value=f"**CPU:** {log_info['CPU']}\n**GPU:** {log_info['GPU']}\n**RAM:** {log_info['RAM']}\n**OS:** {log_info['OS']}",
+                )
+                log_embed.add_field(
+                    name="Ryujinx Info",
+                    value=f"**Version:** {log_info['Ryu_Version']}\n**Firmware:** {log_info['Firmware']}",
                 )
                 if log_info["Game_Name"] == "Unknown":
                     log_embed.add_field(
@@ -69,18 +82,85 @@ class LogFileReader:
                         value=f"This log file appears to be empty. To get a proper log, follow these steps:\n 1) Start a game up.\n 2) Play until your issue occurs.\n 3) Upload your log file.",
                         inline=False,
                     )
+
+                def find_error_message(log_file):
+                    try:
+                        errors = []
+                        curr_error_lines = []
+                        for line in log_file.splitlines():
+                            if "|E|" in line:
+                                curr_error_lines = [line]
+                                errors.append(curr_error_lines)
+                            elif line[0] == " ":
+                                curr_error_lines.append(line)
+                            last_errors = "\n".join(
+                                errors[-1][:2] if "|E|" in errors[-1][0] else ""
+                            )
+                    except IndexError:
+                        last_errors = None
+                    return last_errors
+
+                # finds the lastest error denoted by |E| in the log and its first line
+                error_message = find_error_message(log_file)
+                if error_message:
+                    error_info = f"```{error_message}```"
+                else:
+                    error_info = "No errors found in log"
+                log_embed.add_field(
+                    name="Latest Error Snippet",
+                    value=error_info,
+                    inline=False,
+                )
+
+                # find information on installed mods
+                game_mods = mods_information(log_file)
+                if game_mods:
+                    mods_info = "\n".join(game_mods)
+                else:
+                    mods_info = "No mods found in log"
+                log_embed.add_field(name="Mods", value=mods_info, inline=False)
+
+                # generic checks to notify user about
+                notes = []
+
+                try:
+                    ram_avaliable_regex = re.compile(r"Available\s(\d+)(?=\sMB)")
+                    ram_avaliable = re.search(ram_avaliable_regex, log_file)[1]
+                    if int(ram_avaliable) < 8000:
+                        ram_warning = f"⚠️ less than 8GB RAM avaliable"
+                        notes.append(ram_warning)
+                except TypeError:
+                    pass
+
+                if "Darwin" in log_info["OS"]:
+                    mac_os_warning = f"**❌ macOS is currently unsupported**"
+                    notes.append(mac_os_warning)
+
+                if "Intel" in log_info["GPU"]:
+                    if "Darwin" in log_info["OS"] or "Windows" in log_info["OS"]:
+                        intel_gpu_warning = f"**❌ Intel iGPUs are not supported**"
+                        notes.append(intel_gpu_warning)
+
+                # find information on logs, whether defaults are enabled or not
                 default_logs = ["Info", "Warning", "Error", "Guest", "Stub"]
                 user_logs = (
                     log_info["Logs_Enabled"].rstrip().replace(" ", "").split(",")
                 )
                 disabled_logs = set(default_logs).difference(set(user_logs))
                 if disabled_logs:
-                    logs_warning = [
-                        f":warning: {log} log is not enabled." for log in disabled_logs
+                    logs_status = [
+                        f"⚠️ {log} log is not enabled" for log in disabled_logs
                     ]
-                    log_embed.add_field(
-                        name="Notes", value="\n".join(logs_warning), inline=False
-                    )
+                    log_string = "\n".join(logs_status)
+                else:
+                    log_string = "ℹ️ Default logs enabled"
+                notes.append(log_string)
+                log_embed.add_field(
+                    name="Notes",
+                    value="\n".join([note for note in notes]),
+                    inline=False,
+                )
                 return log_embed
 
+            system_info = specs_search(log_file)
             return generate_log_embed(author, system_info)

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -7,17 +7,19 @@ class LogFileReader:
     def __init__(self, bot):
         self.bot = bot
 
-    async def download_file(log_url):
+    async def download_file(self, log_url):
         async with aiohttp.ClientSession() as session:
-            async with session.get(log_url) as response:
+            # grabs first and last 4kB of log file to prevent abuse from large files
+            headers = {"Range": "bytes=0-6000, -6000"}
+            async with session.get(log_url, headers=headers) as response:
                 return await response.text()
 
-    async def log_file_read(message):
+    async def log_file_read(self, message):
         attached_log = message.attachments[0]
         filename = attached_log.filename
         if re.match(r"^Ryujinx_.*\.log$", filename):
             author = f"@{message.author.name}"
-            log_file = await LogFileReader.download_file(attached_log.url)
+            log_file = await self.download_file(attached_log.url)
 
             regex_map = {
                 "Ryu_Version": "Ryujinx Version",
@@ -25,16 +27,20 @@ class LogFileReader:
                 "OS": "Operating System",
                 "CPU": "CPU",
                 "GPU": "PrintGpuInformation",
-                "RAM": "Total RAM",
+                "RAM": "RAM",
                 "Game_Name": "Loader LoadNca: Application Loaded",
+                "Logs_Enabled": "Logs Enabled",
             }
 
             def make_regex_obj(key, value):
-                return re.compile(fr"{value}: (?P<{key}>.*)$", re.MULTILINE)
+                # since RAM values in log are structured as "RAM: Total 16297 MB ;", regex tries to account for the unneeded 'Total' string
+                return re.compile(
+                    fr"{value}:(\sTotal)?\s(?P<{key}>[^;\r]*)", re.MULTILINE
+                )
 
             def find_specs(body, key, regexobj):
                 match = regexobj.search(body)
-                return match.group(key) if match is not None else None
+                return match.group(key).rstrip() if match is not None else "Unknown"
 
             def specs_search(body):
                 return {
@@ -46,19 +52,35 @@ class LogFileReader:
 
             def generate_log_embed(author_id, log_info):
                 log_embed = discord.Embed(
-                    title=f"{log_info['Game_Name']}", colour=discord.Colour(0x4a90e2)
+                    title=f"{log_info['Game_Name']}", colour=discord.Colour(0x4A90E2)
                 )
                 log_embed.set_footer(text=f"Log uploaded by {author_id}")
                 log_embed.add_field(
-                    name="**Ryujinx Info**",
+                    name="Ryujinx Info",
                     value=f"**Version:** {log_info['Ryu_Version']}\n**Firmware:** {log_info['Firmware']}",
                 )
                 log_embed.add_field(
                     name="Hardware Info",
-                    value=f"**CPU:** {log_info['CPU']}\n**GPU:** {log_info['GPU']}\n**RAM:** {log_info['RAM']}",
+                    value=f"**CPU:** {log_info['CPU']}\n**GPU:** {log_info['GPU']}\n**RAM:** {log_info['RAM']}\n**OS:** {log_info['OS']}",
                 )
+                if log_info["Game_Name"] == "Unknown":
+                    log_embed.add_field(
+                        name="Empty Log",
+                        value=f"This log file appears to be empty. To get a proper log, follow these steps:\n 1) Start a game up.\n 2) Play until your issue occurs.\n 3) Upload your log file.",
+                        inline=False,
+                    )
+                default_logs = ["Info", "Warning", "Error", "Guest", "Stub"]
+                user_logs = (
+                    log_info["Logs_Enabled"].rstrip().replace(" ", "").split(",")
+                )
+                disabled_logs = set(default_logs).difference(set(user_logs))
+                if disabled_logs:
+                    logs_warning = [
+                        f":warning: {log} log is not enabled." for log in disabled_logs
+                    ]
+                    log_embed.add_field(
+                        name="Notes", value="\n".join(logs_warning), inline=False
+                    )
                 return log_embed
 
-            print(system_info)
-            # message = f"This is a valid Ryujinx log file. Thanks <@{author}>"
             return generate_log_embed(author, system_info)

--- a/cogs/ryujinx_verification.py
+++ b/cogs/ryujinx_verification.py
@@ -1,0 +1,94 @@
+import discord
+from discord.ext import commands
+from discord.ext.commands import Cog
+import config
+import random
+from helpers.checks import check_if_staff
+
+
+class RyujinxVerification(Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+        # Export reset channel functions
+        self.bot.do_reset = self.do_reset
+        self.bot.do_resetalgo = self.do_resetalgo
+
+    @Cog.listener()
+    async def on_member_join(self, member):
+        await self.bot.wait_until_ready()
+
+        if (member.guild.id not in config.guild_whitelist):
+            return
+
+        join_channel = self.bot.get_channel(config.welcome_channel)
+
+        if join_channel is not None:
+            await join_channel.send('Hello {0.mention}! Welcome to Ryujinx! Please read the <#411271165429022730>, and then type the verifying command here to gain access to the rest of the channels.\n\nIf you need help with basic common questions, visit the <#585288848704143371> channel after joining.\n\nIf you need help with Animal Crossing visit the <#692104087889641472> channel for common issues and solutions. If you need help that is not Animal Crossing related, please visit the <#410208610455519243> channel after verifying.'.format(member))
+
+    async def process_message(self, message):
+        """Process the verification process"""
+        if message.channel.id == config.welcome_channel:
+            # Assign common stuff into variables to make stuff less of a mess
+            mcl = message.content.lower()
+
+            # Get the role we will give in case of success
+            success_role = message.guild.get_role(config.participant_role)
+
+            if config.verification_string == mcl:
+                await message.author.add_roles(success_role)
+                await message.delete()
+
+    @Cog.listener()
+    async def on_message(self, message):
+        if message.author.bot:
+            return
+
+        try:
+            await self.process_message(message)
+        except discord.errors.Forbidden:
+            chan = self.bot.get_channel(message.channel)
+            await chan.send("💢 I don't have permission to do this.")
+
+    @Cog.listener()
+    async def on_message_edit(self, before, after):
+        if after.author.bot:
+            return
+
+        try:
+            await self.process_message(after)
+        except discord.errors.Forbidden:
+            chan = self.bot.get_channel(after.channel)
+            await chan.send("💢 I don't have permission to do this.")
+
+    @Cog.listener()
+    async def on_member_join(self, member):
+        await self.bot.wait_until_ready()
+
+        if (member.guild.id not in config.guild_whitelist):
+            return
+
+        join_channel = self.bot.get_channel(config.welcome_channel)
+
+        if join_channel is not None:
+            await join_channel.send(config.join_message.format(member))
+
+    @commands.check(check_if_staff)
+    @commands.command()
+    async def reset(self, ctx, limit: int = 100, force: bool = False):
+        """Wipes messages and pastes the welcome message again. Staff only."""
+        if ctx.message.channel.id != config.welcome_channel and not force:
+            await ctx.send(f"This command is limited to"
+                           f" <#{config.welcome_channel}>, unless forced.")
+            return
+        await self.do_reset(ctx.channel, ctx.author.mention, limit)
+
+    async def do_reset(self, channel, author, limit: int = 100):
+        await channel.purge(limit=limit)
+
+    async def do_resetalgo(self, channel, author, limit: int = 100):
+        # We only auto clear the channel daily
+        await self.do_reset(channel, author)
+
+def setup(bot):
+    bot.add_cog(RyujinxVerification(bot))

--- a/config_template.py
+++ b/config_template.py
@@ -50,6 +50,10 @@ initial_cogs = [
 # and sends pins above limit to a github gist
 
 
+# The string that users need to say to get past verification
+verification_string = "go read the rules, not the code"
+
+
 # Minimum account age required to join the guild
 # If user's account creation is shorter than the time delta given here
 # then user will be kicked and informed


### PR DESCRIPTION
This PR adds some log reading functions to the Ryuko bot. Upon uploading of a Ryujinx log file with the format `^Ryujinx_.*\.log$` the bot should be able to read the user's hardware info, operating system and the game name.

In addition, the bot will detect and show which mods are installed, as well as an errors present in the log. The errors shown will be a snippet only, starting from the last error in the log since those can indicate a crash.

If the user meets some criteria a warning will be shown. Currently, these are:

- Having any default logs turned off (Info, Warning, Error, Guest, Stub)
- Having less than 8GB RAM available
- Using macOS
- Using an Intel iGPU on (macOS or Windows)

Here are some previews:

![Screenshot 2021-03-05 162143](https://user-images.githubusercontent.com/36304206/110143245-f0b41200-7dce-11eb-98b7-7a92417ec7e7.png)
![Screenshot 2021-03-05 162251](https://user-images.githubusercontent.com/36304206/110143359-13dec180-7dcf-11eb-949b-ad16e4c9f774.png)
![Screenshot 2021-03-05 162402](https://user-images.githubusercontent.com/36304206/110143514-3a9cf800-7dcf-11eb-9804-2e28e0bb0a00.png)
![Screenshot 2021-03-05 162445](https://user-images.githubusercontent.com/36304206/110143615-50aab880-7dcf-11eb-9523-e3cd28e35c30.png)
![Screenshot 2021-03-05 162509](https://user-images.githubusercontent.com/36304206/110143658-5dc7a780-7dcf-11eb-978b-eb3643b505d9.png)

I have not changed anything else in terms of restricted channels or such, so I shall leave that to the server admins. However I would recommend a `#bot-spam` channel be created, especially as we can look to add more features and detections to the bot.

I would also suggest implementing a `!log` command to show users how to find log files for upload.
