### PR TITLE
Log reading capabilities to Ryuko bot

### DIFF
--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -1,5 +1,5 @@
-from inspect import Traceback
 import logging
+from typing import Type
 import discord
 from discord.ext.commands import Cog
 import re
@@ -27,66 +27,160 @@ class LogFileReader(Cog):
                 return await response.text("UTF-8")
 
     async def log_file_read(self, message):
+        self.embed = {
+            "hardware_info": {
+                "cpu": "Unknown",
+                "gpu": "Unknown",
+                "ram": "Unknown",
+                "os": "Unknown",
+            },
+            "emu_info": {
+                "ryu_version": "Unknown",
+                "ryu_firmware": "Unknown",
+                "logs_enabled": None,
+            },
+            "game_info": {
+                "game_name": "Unknown",
+                "errors": "No errors found in log",
+                "mods": "No mods found",
+                "notes": [],
+            },
+            "user_settings": {
+                "pptc": "Unknown",
+            },
+        }
         attached_log = message.attachments[0]
-        author = f"@{message.author.name}"
+        author_name = f"@{message.author.name}"
         log_file = await self.download_file(attached_log.url)
         # Large files show a header value when not downloaded completely
         # this regex makes sure that the log text to read starts from the first timestamp, ignoring headers
         log_file_header_regex = re.compile(r"\d{2}:\d{2}:\d{2}\.\d{3}.*", re.DOTALL)
         log_file = re.search(log_file_header_regex, log_file).group(0)
 
-        regex_map = {
-            "Ryu_Version": "Ryujinx Version",
-            "Firmware": "Firmware Version",
-            "OS": "Operating System",
-            "CPU": "CPU",
-            "GPU": "PrintGpuInformation",
-            "RAM": "RAM",
-            "Game_Name": "Loader LoadNca: Application Loaded",
-            "Logs_Enabled": "Logs Enabled",
-        }
+        def get_hardware_info(log_file):
+            try:
+                self.embed["hardware_info"]["cpu"] = (
+                    re.search(r"CPU:\s([^;\r]*)", log_file, re.MULTILINE)
+                    .group(1)
+                    .rstrip()
+                )
+                self.embed["hardware_info"]["ram"] = (
+                    re.search(r"RAM:(\sTotal)?\s([^;\r]*)", log_file, re.MULTILINE)
+                    .group(2)
+                    .rstrip()
+                )
+                self.embed["hardware_info"]["os"] = (
+                    re.search(r"Operating System:\s([^;\r]*)", log_file, re.MULTILINE)
+                    .group(1)
+                    .rstrip()
+                )
+                self.embed["hardware_info"]["gpu"] = (
+                    re.search(
+                        r"PrintGpuInformation:\s([^;\r]*)", log_file, re.MULTILINE
+                    )
+                    .group(1)
+                    .rstrip()
+                )
+            except AttributeError:
+                pass
 
-        def make_regex_obj(key, value):
-            # Since RAM values in log are structured as "RAM: Total 16297 MB ;", regex tries to account for the unneeded 'Total' string
-            return re.compile(fr"{value}:(\sTotal)?\s(?P<{key}>[^;\r]*)", re.MULTILINE)
+        def get_ryujinx_info(log_file):
+            self.embed["emu_info"]["ryu_version"] = (
+                re.search(r"Ryujinx Version:\s([^;\r]*)", log_file, re.MULTILINE)
+                .group(1)
+                .rstrip()
+            )
+            self.embed["emu_info"]["ryu_firmware"] = (
+                re.search(r"Firmware Version:\s([^;\r]*)", log_file, re.MULTILINE)
+                .group(1)
+                .rstrip()
+            )
+            self.embed["emu_info"]["logs_enabled"] = (
+                re.search(r"Logs Enabled:\s([^;\r]*)", log_file, re.MULTILINE)
+                .group(1)
+                .rstrip()
+            )
 
-        def find_specs(body, key, regexobj):
-            match = regexobj.search(body)
-            return match.group(key).rstrip() if match is not None else "Unknown"
+        def format_log_embed():
+            cleaned_game_name = re.sub(
+                r"\s\[(64|32)-bit\]$", "", self.embed["game_info"]["game_name"]
+            )
+            self.embed["game_info"]["game_name"] = cleaned_game_name
 
-        def specs_search(body):
-            return {
-                key: find_specs(body, key, make_regex_obj(key, value))
-                for key, value in regex_map.items()
-            }
+            hardware_info = "\n".join(
+                (
+                    f"**CPU:** {self.embed['hardware_info']['cpu']}",
+                    f"**GPU:** {self.embed['hardware_info']['gpu']}",
+                    f"**RAM:** {self.embed['hardware_info']['ram']}",
+                    f"**OS:** {self.embed['hardware_info']['os']}",
+                )
+            )
 
-        def mods_information(log_file):
-            mods_regex = re.compile(r"Found mod\s\'(.+?)\'\s(\[.+?\])")
-            matches = re.findall(mods_regex, log_file)
-            if matches:
-                mods = [{"mod": match[0], "status": match[1]} for match in matches]
-                mods_status = [
-                    f"ℹ️ {i['mod']} ({'ExeFS' if i['status'] == '[E]' else 'RomFS'})"
-                    for i in mods
-                ]
-                return mods_status
+            user_settings_info = "\n".join(
+                (f"**PPTC:** {self.embed['user_settings']['pptc']}",)
+            )
 
-        def generate_log_embed(author_id, log_info):
-            embed = {
-                "hardware_info": {
-                    "cpu": "Unknown",
-                    "gpu": "Unknown",
-                    "ram": "Unknown",
-                    "os": "Unknown",
-                },
-                "emu_info": {"ryu_version": "Unknown", "ryu_firmware": "Unknown"},
-                "game_info": {
-                    "game_name": "Unknown",
-                    "errors": "No errors found in log",
-                    "mods": "No mods found",
-                    "notes": [],
-                },
-            }
+            ryujinx_info = "\n".join(
+                (
+                    f"**Version:** {self.embed['emu_info']['ryu_version']}",
+                    f"**Firmware:** {self.embed['emu_info']['ryu_firmware']}",
+                )
+            )
+
+            log_embed = discord.Embed(
+                title=f"{cleaned_game_name}", colour=discord.Colour(0x4A90E2)
+            )
+            log_embed.set_footer(text=f"Log uploaded by {author_name}")
+            log_embed.add_field(name="Hardware Info", value=hardware_info)
+            log_embed.add_field(name="Ryujinx Info", value=ryujinx_info)
+            if cleaned_game_name == "Unknown":
+                log_embed.add_field(
+                    name="Empty Log",
+                    value="""This log file appears to be empty. To get a proper log, follow these steps:
+                        \n 1) Start a game up.
+                        \n 2) Play until your issue occurs.
+                        \n 3) Upload your log file.""",
+                    inline=False,
+                )
+            log_embed.add_field(
+                name="Settings",
+                value=user_settings_info,
+                inline=False,
+            )
+            log_embed.add_field(
+                name="Latest Error Snippet",
+                value=self.embed["game_info"]["errors"],
+                inline=False,
+            )
+            log_embed.add_field(
+                name="Mods", value=self.embed["game_info"]["mods"], inline=False
+            )
+            log_embed.add_field(
+                name="Notes",
+                value="\n".join([note for note in self.embed["game_info"]["notes"]]),
+                inline=False,
+            )
+
+            return log_embed
+
+        def analyse_log(log_file):
+            self.embed["game_info"]["game_name"] = (
+                re.search(
+                    r"Loader LoadNca: Application Loaded:\s([^;\r]*)",
+                    log_file,
+                    re.MULTILINE,
+                )
+                .group(1)
+                .rstrip()
+            )
+
+            pptc_setting = re.search(
+                r"Ptc Initialize:.+\(enabled:\s(.+?)\)[^;\r]", log_file, re.MULTILINE
+            ).group(1)
+            if pptc_setting == "True":
+                self.embed["user_settings"]["pptc"] = "Enabled"
+            else:
+                self.embed["user_settings"]["pptc"] = "Disabled"
 
             def find_error_message(log_file):
                 try:
@@ -110,14 +204,25 @@ class LogFileReader(Cog):
             # Finds the lastest error denoted by |E| in the log and its first line
             error_message = find_error_message(log_file)
             if error_message:
-                embed["game_info"]["errors"] = f"```{error_message}```"
+                self.embed["game_info"]["errors"] = f"```{error_message}```"
             else:
                 pass
+
+            def mods_information(log_file):
+                mods_regex = re.compile(r"Found mod\s\'(.+?)\'\s(\[.+?\])")
+                matches = re.findall(mods_regex, log_file)
+                if matches:
+                    mods = [{"mod": match[0], "status": match[1]} for match in matches]
+                    mods_status = [
+                        f"ℹ️ {i['mod']} ({'ExeFS' if i['status'] == '[E]' else 'RomFS'})"
+                        for i in mods
+                    ]
+                    return mods_status
 
             # Find information on installed mods
             game_mods = mods_information(log_file)
             if game_mods:
-                embed["game_info"]["mods"] = "\n".join(game_mods)
+                self.embed["game_info"]["mods"] = "\n".join(game_mods)
             else:
                 pass
 
@@ -128,96 +233,50 @@ class LogFileReader(Cog):
                 input_string = "\n".join(input_status)
             else:
                 input_string = "⚠️ No controller information found"
-            embed["game_info"]["notes"].append(input_string)
+            self.embed["game_info"]["notes"].append(input_string)
 
             try:
                 ram_avaliable_regex = re.compile(r"Available\s(\d+)(?=\sMB)")
                 ram_avaliable = re.search(ram_avaliable_regex, log_file)[1]
                 if int(ram_avaliable) < 8000:
                     ram_warning = "⚠️ Less than 8GB RAM avaliable"
-                    embed["game_info"]["notes"].append(ram_warning)
+                    self.embed["game_info"]["notes"].append(ram_warning)
             except TypeError:
                 pass
 
-            if "Darwin" in log_info["OS"]:
+            if "Darwin" in self.embed["hardware_info"]["os"]:
                 mac_os_warning = "**❌ macOS is currently unsupported**"
-                embed["game_info"]["notes"].append(mac_os_warning)
+                self.embed["game_info"]["notes"].append(mac_os_warning)
 
-            if "Intel" in log_info["GPU"]:
-                if "Darwin" in log_info["OS"] or "Windows" in log_info["OS"]:
+            if "Intel" in self.embed["hardware_info"]["gpu"]:
+                if (
+                    "Darwin" in self.embed["hardware_info"]["os"]
+                    or "Windows" in self.embed["hardware_info"]["os"]
+                ):
                     intel_gpu_warning = "**⚠️ Intel iGPUs are known to have driver issues, consider using a discrete GPU**"
-                    embed["game_info"]["notes"].append(intel_gpu_warning)
+                    self.embed["game_info"]["notes"].append(intel_gpu_warning)
 
             # Find information on logs, whether defaults are enabled or not
             default_logs = ["Info", "Warning", "Error", "Guest", "Stub"]
-            user_logs = log_info["Logs_Enabled"].rstrip().replace(" ", "").split(",")
+            user_logs = (
+                self.embed["emu_info"]["logs_enabled"]
+                .rstrip()
+                .replace(" ", "")
+                .split(",")
+            )
             disabled_logs = set(default_logs).difference(set(user_logs))
             if disabled_logs:
                 logs_status = [f"⚠️ {log} log is not enabled" for log in disabled_logs]
                 log_string = "\n".join(logs_status)
             else:
                 log_string = "✅ Default logs enabled"
-            embed["game_info"]["notes"].append(log_string)
+            self.embed["game_info"]["notes"].append(log_string)
 
-            embed["hardware_info"]["cpu"] = log_info["CPU"]
-            embed["hardware_info"]["gpu"] = log_info["GPU"]
-            embed["hardware_info"]["ram"] = log_info["RAM"]
-            embed["hardware_info"]["os"] = log_info["OS"]
-            embed["emu_info"]["ryu_version"] = log_info["Ryu_Version"]
-            embed["emu_info"]["ryu_firmware"] = log_info["Firmware"]
+        get_hardware_info(log_file)
+        get_ryujinx_info(log_file)
+        analyse_log(log_file)
 
-            cleaned_game_name = re.sub(r"\s\[(64|32)-bit\]$", "", log_info["Game_Name"])
-            embed["game_info"]["game_name"] = cleaned_game_name
-
-            hardware_info = "\n".join(
-                (
-                    f"**CPU:** {embed['hardware_info']['cpu']}",
-                    f"**GPU:** {embed['hardware_info']['gpu']}",
-                    f"**RAM:** {embed['hardware_info']['ram']}",
-                    f"**OS:** {embed['hardware_info']['os']}",
-                )
-            )
-
-            ryujinx_info = "\n".join(
-                (
-                    f"**Version:** {embed['emu_info']['ryu_version']}",
-                    f"**Firmware:** {embed['emu_info']['ryu_firmware']}",
-                )
-            )
-
-            log_embed = discord.Embed(
-                title=f"{cleaned_game_name}", colour=discord.Colour(0x4A90E2)
-            )
-            log_embed.set_footer(text=f"Log uploaded by {author_id}")
-            log_embed.add_field(name="Hardware Info", value=hardware_info)
-            log_embed.add_field(name="Ryujinx Info", value=ryujinx_info)
-            if log_info["Game_Name"] == "Unknown":
-                log_embed.add_field(
-                    name="Empty Log",
-                    value="""This log file appears to be empty. To get a proper log, follow these steps:
-                    \n 1) Start a game up.
-                    \n 2) Play until your issue occurs.
-                    \n 3) Upload your log file.""",
-                    inline=False,
-                )
-            log_embed.add_field(
-                name="Latest Error Snippet",
-                value=embed["game_info"]["errors"],
-                inline=False,
-            )
-            log_embed.add_field(
-                name="Mods", value=embed["game_info"]["mods"], inline=False
-            )
-            log_embed.add_field(
-                name="Notes",
-                value="\n".join([note for note in embed["game_info"]["notes"]]),
-                inline=False,
-            )
-
-            return log_embed
-
-        system_info = specs_search(log_file)
-        return generate_log_embed(author, system_info)
+        return format_log_embed()
 
     @Cog.listener()
     async def on_message(self, message):
@@ -227,7 +286,7 @@ class LogFileReader(Cog):
 
         # If message has an attachment
         try:
-            author = message.author.mention
+            author_mention = message.author.mention
             filename = message.attachments[0].filename
             # Any message over 2000 chars is uploaded as message.txt, so this is accounted for
             log_file_regex = re.compile(r"^Ryujinx_.*\.log|message\.txt$")
@@ -249,7 +308,7 @@ class LogFileReader(Cog):
                         return await reply_message.edit(content=None, embed=embed)
                     except UnicodeDecodeError:
                         return await message.channel.send(
-                            f"This log file appears to be invalid {author}. Please re-check and re-upload your log file."
+                            f"This log file appears to be invalid {author_mention}. Please re-check and re-upload your log file."
                         )
                     except Exception as error:
                         await reply_message.edit(
@@ -258,15 +317,15 @@ class LogFileReader(Cog):
                         print(logging.warn(error))
                 else:
                     await message.channel.send(
-                        f"The log file `{filename}` appears to be a duplicate {author}. Please upload a more recent file."
+                        f"The log file `{filename}` appears to be a duplicate {author_mention}. Please upload a more recent file."
                     )
             elif not is_log_file:
                 return await message.channel.send(
-                    f"{author} Your file does not match the Ryujinx log format. Please check your file."
+                    f"{author_mention} Your file does not match the Ryujinx log format. Please check your file."
                 )
             else:
                 return await message.channel.send(
-                    f"{author} Please upload log files to {' or '.join([f'<#{id}>' for id in self.bot_log_allowed_channels])}"
+                    f"{author_mention} Please upload log files to {' or '.join([f'<#{id}>' for id in self.bot_log_allowed_channels])}"
                 )
         except IndexError:
             pass

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -1,0 +1,214 @@
+from logging import log
+import discord
+from discord.ext.commands import Cog
+import re
+import aiohttp
+
+
+class LogFileReader(Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        # Allows log analysis in #support and #patreon-support channels respectively
+        # self.log_allowed_channels = [410208610455519243, 692449072107225108]
+        self.log_allowed_channels = [818828123461386260]
+        self.uploaded_log_filenames = []
+
+    async def download_file(self, log_url):
+        async with aiohttp.ClientSession() as session:
+            # grabs first and last 4kB of log file to prevent abuse from large files
+            headers = {"Range": "bytes=0-20000, -6000"}
+            async with session.get(log_url, headers=headers) as response:
+                return await response.text("UTF-8")
+
+    async def log_file_read(self, message):
+        attached_log = message.attachments[0]
+        author = f"@{message.author.name}"
+        log_file = await self.download_file(attached_log.url)
+
+        regex_map = {
+            "Ryu_Version": "Ryujinx Version",
+            "Firmware": "Firmware Version",
+            "OS": "Operating System",
+            "CPU": "CPU",
+            "GPU": "PrintGpuInformation",
+            "RAM": "RAM",
+            "Game_Name": "Loader LoadNca: Application Loaded",
+            "Logs_Enabled": "Logs Enabled",
+        }
+
+        def make_regex_obj(key, value):
+            # since RAM values in log are structured as "RAM: Total 16297 MB ;", regex tries to account for the unneeded 'Total' string
+            return re.compile(fr"{value}:(\sTotal)?\s(?P<{key}>[^;\r]*)", re.MULTILINE)
+
+        def find_specs(body, key, regexobj):
+            match = regexobj.search(body)
+            return match.group(key).rstrip() if match is not None else "Unknown"
+
+        def specs_search(body):
+            return {
+                key: find_specs(body, key, make_regex_obj(key, value))
+                for key, value in regex_map.items()
+            }
+
+        def mods_information(log_file):
+            mods_regex = re.compile(r"Found mod\s\'(.+?)\'\s(\[.+?\])")
+            matches = re.findall(mods_regex, log_file)
+            if matches:
+                mods = [{"mod": match[0], "status": match[1]} for match in matches]
+                mods_status = [
+                    f"ℹ️ {i['mod']} ({'ExeFS' if i['status'] == '[E]' else 'RomFS'})"
+                    for i in mods
+                ]
+                return mods_status
+
+        def generate_log_embed(author_id, log_info):
+            cleaned_game_name = re.sub(r"\s\[(64|32)-bit\]$", "", log_info["Game_Name"])
+            log_embed = discord.Embed(
+                title=f"{cleaned_game_name}", colour=discord.Colour(0x4A90E2)
+            )
+            log_embed.set_footer(text=f"Log uploaded by {author_id}")
+            log_embed.add_field(
+                name="Hardware Info",
+                value=f"**CPU:** {log_info['CPU']}\n**GPU:** {log_info['GPU']}\n**RAM:** {log_info['RAM']}\n**OS:** {log_info['OS']}",
+            )
+            log_embed.add_field(
+                name="Ryujinx Info",
+                value=f"**Version:** {log_info['Ryu_Version']}\n**Firmware:** {log_info['Firmware']}",
+            )
+            if log_info["Game_Name"] == "Unknown":
+                log_embed.add_field(
+                    name="Empty Log",
+                    value=f"This log file appears to be empty. To get a proper log, follow these steps:\n 1) Start a game up.\n 2) Play until your issue occurs.\n 3) Upload your log file.",
+                    inline=False,
+                )
+
+            def find_error_message(log_file):
+                try:
+                    errors = []
+                    curr_error_lines = []
+                    for line in log_file.splitlines():
+                        if "|E|" in line:
+                            curr_error_lines = [line]
+                            errors.append(curr_error_lines)
+                        elif line[0] == " ":
+                            curr_error_lines.append(line)
+                    last_errors = "\n".join(
+                        errors[-1][:2] if "|E|" in errors[-1][0] else ""
+                    )
+                except IndexError:
+                    last_errors = None
+                return last_errors
+
+            # finds the lastest error denoted by |E| in the log and its first line
+            error_message = find_error_message(log_file)
+            if error_message:
+                error_info = f"```{error_message}```"
+            else:
+                error_info = "No errors found in log"
+            log_embed.add_field(
+                name="Latest Error Snippet",
+                value=error_info,
+                inline=False,
+            )
+
+            # find information on installed mods
+            game_mods = mods_information(log_file)
+            if game_mods:
+                mods_info = "\n".join(game_mods)
+            else:
+                mods_info = "No mods found"
+            log_embed.add_field(name="Mods", value=mods_info, inline=False)
+
+            # generic checks to notify user about
+            notes = []
+
+            controllers_regex = re.compile(r"Hid Configure: ([^\r\n]+)")
+            controllers = re.findall(controllers_regex, log_file)
+            if controllers:
+                input_status = [f"ℹ {match}" for match in controllers]
+                input_string = "\n".join(input_status)
+            else:
+                input_string = "⚠️ No controller information found"
+            notes.append(input_string)
+
+            try:
+                ram_avaliable_regex = re.compile(r"Available\s(\d+)(?=\sMB)")
+                ram_avaliable = re.search(ram_avaliable_regex, log_file)[1]
+                if int(ram_avaliable) < 8000:
+                    ram_warning = f"⚠️ Less than 8GB RAM avaliable"
+                    notes.append(ram_warning)
+            except TypeError:
+                pass
+
+            if "Darwin" in log_info["OS"]:
+                mac_os_warning = f"**❌ macOS is currently unsupported**"
+                notes.append(mac_os_warning)
+
+            if "Intel" in log_info["GPU"]:
+                if "Darwin" in log_info["OS"] or "Windows" in log_info["OS"]:
+                    intel_gpu_warning = f"**❌ Intel iGPUs are not supported**"
+                    notes.append(intel_gpu_warning)
+
+            # find information on logs, whether defaults are enabled or not
+            default_logs = ["Info", "Warning", "Error", "Guest", "Stub"]
+            user_logs = log_info["Logs_Enabled"].rstrip().replace(" ", "").split(",")
+            disabled_logs = set(default_logs).difference(set(user_logs))
+            if disabled_logs:
+                logs_status = [f"⚠️ {log} log is not enabled" for log in disabled_logs]
+                log_string = "\n".join(logs_status)
+            else:
+                log_string = "ℹ️ Default logs enabled"
+            notes.append(log_string)
+            log_embed.add_field(
+                name="Notes",
+                value="\n".join([note for note in notes]),
+                inline=False,
+            )
+            return log_embed
+
+        system_info = specs_search(log_file)
+        return generate_log_embed(author, system_info)
+
+    @Cog.listener()
+    async def on_message(self, message):
+        await self.bot.wait_until_ready()
+        if message.author.bot:
+            return
+
+        # If message has an attachment
+        try:
+            author = message.author.mention
+            filename = message.attachments[0].filename
+            log_file_regex = re.compile(r"^Ryujinx_.*\.log|message\.txt$")
+            is_log_file = re.match(log_file_regex, filename)
+            if message.channel.id in self.log_allowed_channels and is_log_file:
+                if filename not in self.uploaded_log_filenames:
+                    embed = await self.log_file_read(message)
+                    if "Ryujinx_" in filename:
+                        self.uploaded_log_filenames.append(filename)
+                        # Avoid duplicate log file analysis, at least temporarily; keep track of the last few filenames of uploaded logs
+                        # this should help support channels not be flooded with too many log files
+                        self.uploaded_log_filenames = self.uploaded_log_filenames[-5:]
+                    return await message.channel.send(embed=embed)
+                else:
+                    return await message.channel.send(
+                        f"The log file `{filename}` appears to be a duplicate {author}. Please upload a more recent file."
+                    )
+            elif not is_log_file:
+                return await message.channel.send(
+                    f"{author} Your file does not match the Ryujinx log format. Please check your file."
+                )
+            else:
+                return await message.channel.send(
+                    f"{author} Please upload log files to {' or '.join([f'<#{id}>' for id in self.log_allowed_channels])}"
+                )
+        except IndexError:
+            pass
+        except UnicodeDecodeError:
+            return await message.channel.send(
+                f"This log file appears to be invalid {author}. Please re-check and re-upload your log file."
+            )
+
+
+def setup(bot):
+    bot.add_cog(LogFileReader(bot))

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -207,8 +207,10 @@ class LogFileReader(Cog):
                             self.uploaded_log_filenames = self.uploaded_log_filenames[
                                 -5:
                             ]
-                        return await reply_message.channel.edit(
-                            content=None, embed=embed
+                        return await reply_message.edit(content=None, embed=embed)
+                    except UnicodeDecodeError:
+                        return await message.channel.send(
+                            f"This log file appears to be invalid {author}. Please re-check and re-upload your log file."
                         )
                     except Exception as error:
                         await reply_message.edit(
@@ -229,10 +231,6 @@ class LogFileReader(Cog):
                 )
         except IndexError:
             pass
-        except UnicodeDecodeError:
-            return await message.channel.send(
-                f"This log file appears to be invalid {author}. Please re-check and re-upload your log file."
-            )
 
 
 def setup(bot):

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -30,7 +30,7 @@ class LogFileReader(Cog):
         attached_log = message.attachments[0]
         author = f"@{message.author.name}"
         log_file = await self.download_file(attached_log.url)
-        # Large files show a header value when not downlodaed completely
+        # Large files show a header value when not downloaded completely
         # this regex makes sure that the log text to read starts from the first timestamp, ignoring headers
         log_file_header_regex = re.compile(r"\d{2}:\d{2}:\d{2}\.\d{3}.*", re.DOTALL)
         log_file = re.search(log_file_header_regex, log_file).group(0)
@@ -72,25 +72,21 @@ class LogFileReader(Cog):
                 return mods_status
 
         def generate_log_embed(author_id, log_info):
-            cleaned_game_name = re.sub(r"\s\[(64|32)-bit\]$", "", log_info["Game_Name"])
-            log_embed = discord.Embed(
-                title=f"{cleaned_game_name}", colour=discord.Colour(0x4A90E2)
-            )
-            log_embed.set_footer(text=f"Log uploaded by {author_id}")
-            log_embed.add_field(
-                name="Hardware Info",
-                value=f"**CPU:** {log_info['CPU']}\n**GPU:** {log_info['GPU']}\n**RAM:** {log_info['RAM']}\n**OS:** {log_info['OS']}",
-            )
-            log_embed.add_field(
-                name="Ryujinx Info",
-                value=f"**Version:** {log_info['Ryu_Version']}\n**Firmware:** {log_info['Firmware']}",
-            )
-            if log_info["Game_Name"] == "Unknown":
-                log_embed.add_field(
-                    name="Empty Log",
-                    value=f"This log file appears to be empty. To get a proper log, follow these steps:\n 1) Start a game up.\n 2) Play until your issue occurs.\n 3) Upload your log file.",
-                    inline=False,
-                )
+            embed = {
+                "hardware_info": {
+                    "cpu": "Unknown",
+                    "gpu": "Unknown",
+                    "ram": "Unknown",
+                    "os": "Unknown",
+                },
+                "emu_info": {"ryu_version": "Unknown", "ryu_firmware": "Unknown"},
+                "game_info": {
+                    "game_name": "Unknown",
+                    "errors": "No errors found in log",
+                    "mods": "No mods found",
+                    "notes": [],
+                },
+            }
 
             def find_error_message(log_file):
                 try:
@@ -114,25 +110,16 @@ class LogFileReader(Cog):
             # Finds the lastest error denoted by |E| in the log and its first line
             error_message = find_error_message(log_file)
             if error_message:
-                error_info = f"```{error_message}```"
+                embed["game_info"]["errors"] = f"```{error_message}```"
             else:
-                error_info = "No errors found in log"
-            log_embed.add_field(
-                name="Latest Error Snippet",
-                value=error_info,
-                inline=False,
-            )
+                pass
 
             # Find information on installed mods
             game_mods = mods_information(log_file)
             if game_mods:
-                mods_info = "\n".join(game_mods)
+                embed["game_info"]["mods"] = "\n".join(game_mods)
             else:
-                mods_info = "No mods found"
-            log_embed.add_field(name="Mods", value=mods_info, inline=False)
-
-            # Generic checks to notify user about
-            notes = []
+                pass
 
             controllers_regex = re.compile(r"Hid Configure: ([^\r\n]+)")
             controllers = re.findall(controllers_regex, log_file)
@@ -141,25 +128,25 @@ class LogFileReader(Cog):
                 input_string = "\n".join(input_status)
             else:
                 input_string = "⚠️ No controller information found"
-            notes.append(input_string)
+            embed["game_info"]["notes"].append(input_string)
 
             try:
                 ram_avaliable_regex = re.compile(r"Available\s(\d+)(?=\sMB)")
                 ram_avaliable = re.search(ram_avaliable_regex, log_file)[1]
                 if int(ram_avaliable) < 8000:
-                    ram_warning = f"⚠️ Less than 8GB RAM avaliable"
-                    notes.append(ram_warning)
+                    ram_warning = "⚠️ Less than 8GB RAM avaliable"
+                    embed["game_info"]["notes"].append(ram_warning)
             except TypeError:
                 pass
 
             if "Darwin" in log_info["OS"]:
-                mac_os_warning = f"**❌ macOS is currently unsupported**"
-                notes.append(mac_os_warning)
+                mac_os_warning = "**❌ macOS is currently unsupported**"
+                embed["game_info"]["notes"].append(mac_os_warning)
 
             if "Intel" in log_info["GPU"]:
                 if "Darwin" in log_info["OS"] or "Windows" in log_info["OS"]:
-                    intel_gpu_warning = f"**❌ Intel iGPUs are not supported**"
-                    notes.append(intel_gpu_warning)
+                    intel_gpu_warning = "**⚠️ Intel iGPUs are known to have driver issues, consider using a discrete GPU**"
+                    embed["game_info"]["notes"].append(intel_gpu_warning)
 
             # Find information on logs, whether defaults are enabled or not
             default_logs = ["Info", "Warning", "Error", "Guest", "Stub"]
@@ -170,12 +157,63 @@ class LogFileReader(Cog):
                 log_string = "\n".join(logs_status)
             else:
                 log_string = "✅ Default logs enabled"
-            notes.append(log_string)
+            embed["game_info"]["notes"].append(log_string)
+
+            embed["hardware_info"]["cpu"] = log_info["CPU"]
+            embed["hardware_info"]["gpu"] = log_info["GPU"]
+            embed["hardware_info"]["ram"] = log_info["RAM"]
+            embed["hardware_info"]["os"] = log_info["OS"]
+            embed["emu_info"]["ryu_version"] = log_info["Ryu_Version"]
+            embed["emu_info"]["ryu_firmware"] = log_info["Firmware"]
+
+            cleaned_game_name = re.sub(r"\s\[(64|32)-bit\]$", "", log_info["Game_Name"])
+            embed["game_info"]["game_name"] = cleaned_game_name
+
+            hardware_info = "\n".join(
+                (
+                    f"**CPU:** {embed['hardware_info']['cpu']}",
+                    f"**GPU:** {embed['hardware_info']['gpu']}",
+                    f"**RAM:** {embed['hardware_info']['ram']}",
+                    f"**OS:** {embed['hardware_info']['os']}",
+                )
+            )
+
+            ryujinx_info = "\n".join(
+                (
+                    f"**Version:** {embed['emu_info']['ryu_version']}",
+                    f"**Firmware:** {embed['emu_info']['ryu_firmware']}",
+                )
+            )
+
+            log_embed = discord.Embed(
+                title=f"{cleaned_game_name}", colour=discord.Colour(0x4A90E2)
+            )
+            log_embed.set_footer(text=f"Log uploaded by {author_id}")
+            log_embed.add_field(name="Hardware Info", value=hardware_info)
+            log_embed.add_field(name="Ryujinx Info", value=ryujinx_info)
+            if log_info["Game_Name"] == "Unknown":
+                log_embed.add_field(
+                    name="Empty Log",
+                    value="""This log file appears to be empty. To get a proper log, follow these steps:
+                    \n 1) Start a game up.
+                    \n 2) Play until your issue occurs.
+                    \n 3) Upload your log file.""",
+                    inline=False,
+                )
             log_embed.add_field(
-                name="Notes",
-                value="\n".join([note for note in notes]),
+                name="Latest Error Snippet",
+                value=embed["game_info"]["errors"],
                 inline=False,
             )
+            log_embed.add_field(
+                name="Mods", value=embed["game_info"]["mods"], inline=False
+            )
+            log_embed.add_field(
+                name="Notes",
+                value="\n".join([note for note in embed["game_info"]["notes"]]),
+                inline=False,
+            )
+
             return log_embed
 
         system_info = specs_search(log_file)
@@ -191,6 +229,7 @@ class LogFileReader(Cog):
         try:
             author = message.author.mention
             filename = message.attachments[0].filename
+            # Any message over 2000 chars is uploaded as message.txt, so this is accounted for
             log_file_regex = re.compile(r"^Ryujinx_.*\.log|message\.txt$")
             is_log_file = re.match(log_file_regex, filename)
             if message.channel.id in self.bot_log_allowed_channels and is_log_file:

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -9,7 +9,7 @@ from discord.ext.commands import Cog
 
 logging.basicConfig(
     format="%(asctime)s (%(levelname)s) %(message)s (Line %(lineno)d)",
-    level=logging.DEBUG,
+    level=logging.INFO,
 )
 
 

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -367,10 +367,12 @@ class LogFileReader(Cog):
                 self.embed["game_info"]["notes"].append(input_string)
 
                 try:
-                    ram_avaliable_regex = re.compile(r"Available\s(\d+)(?=\sMB)")
-                    ram_avaliable = re.search(ram_avaliable_regex, log_file)[1]
-                    if int(ram_avaliable) < 8000:
-                        ram_warning = "⚠️ Less than 8GB RAM avaliable"
+                    ram_available_regex = re.compile(r"Available\s(\d+)(?=\sMB)")
+                    ram_available = re.search(ram_available_regex, log_file)[1]
+                    if int(ram_available) < 8000:
+                        ram_warning = (
+                            f"⚠️ Less than 8GB RAM available ({str(ram_available)} MB)"
+                        )
                         self.embed["game_info"]["notes"].append(ram_warning)
                 except TypeError:
                     pass
@@ -418,7 +420,11 @@ class LogFileReader(Cog):
                     )
 
                 game_notes = [note for note in self.embed["game_info"]["notes"]]
-                ordered_game_notes = sorted(game_notes, key=severity)
+                # Warnings split on the string after the warning symbol for alphabetical ordering
+                # Severity key then orders alphabetically sorted warnings to show most severe first
+                ordered_game_notes = sorted(
+                    sorted(game_notes, key=lambda x: x.split()[1]), key=severity
+                )
 
                 return ordered_game_notes
             except AttributeError:

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -3,14 +3,14 @@ import discord
 from discord.ext.commands import Cog
 import re
 import aiohttp
+import config
 
 
 class LogFileReader(Cog):
     def __init__(self, bot):
         self.bot = bot
         # Allows log analysis in #support and #patreon-support channels respectively
-        # self.log_allowed_channels = [410208610455519243, 692449072107225108]
-        self.log_allowed_channels = [818828123461386260]
+        self.bot_log_allowed_channels = config.bot_log_allowed_channels
         self.uploaded_log_filenames = []
 
     async def download_file(self, log_url):
@@ -181,7 +181,7 @@ class LogFileReader(Cog):
             filename = message.attachments[0].filename
             log_file_regex = re.compile(r"^Ryujinx_.*\.log|message\.txt$")
             is_log_file = re.match(log_file_regex, filename)
-            if message.channel.id in self.log_allowed_channels and is_log_file:
+            if message.channel.id in self.bot_log_allowed_channels and is_log_file:
                 if filename not in self.uploaded_log_filenames:
                     embed = await self.log_file_read(message)
                     if "Ryujinx_" in filename:
@@ -200,7 +200,7 @@ class LogFileReader(Cog):
                 )
             else:
                 return await message.channel.send(
-                    f"{author} Please upload log files to {' or '.join([f'<#{id}>' for id in self.log_allowed_channels])}"
+                    f"{author} Please upload log files to {' or '.join([f'<#{id}>' for id in self.bot_log_allowed_channels])}"
                 )
         except IndexError:
             pass

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -163,7 +163,7 @@ class LogFileReader(Cog):
                 logs_status = [f"⚠️ {log} log is not enabled" for log in disabled_logs]
                 log_string = "\n".join(logs_status)
             else:
-                log_string = "ℹ️ Default logs enabled"
+                log_string = "✅ Default logs enabled"
             notes.append(log_string)
             log_embed.add_field(
                 name="Notes",

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -424,6 +424,12 @@ class LogFileReader(Cog):
                     firmware_warning = f"**❌ Nintendo Switch firmware not found**"
                     self.embed["game_info"]["notes"].append(firmware_warning)
 
+                if "dirty" in self.embed["emu_info"]["ryu_version"]:
+                    custom_firmware_warning = (
+                        "**⚠️ Custom builds are not officially supported**"
+                    )
+                    self.embed["game_info"]["notes"].append(custom_firmware_warning)
+
                 def severity(log_note_string):
                     symbols = ["❌", "⚠️", "ℹ", "✅"]
                     return next(

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -66,7 +66,7 @@ class LogFileReader(Cog):
         log_file_header_regex = re.compile(r"\d{2}:\d{2}:\d{2}\.\d{3}.*", re.DOTALL)
         log_file = re.search(log_file_header_regex, log_file).group(0)
 
-        def get_hardware_info(log_file):
+        def get_hardware_info(log_file=log_file):
             try:
                 self.embed["hardware_info"]["cpu"] = (
                     re.search(r"CPU:\s([^;\r]*)", log_file, re.MULTILINE)
@@ -93,7 +93,7 @@ class LogFileReader(Cog):
             except AttributeError:
                 pass
 
-        def get_ryujinx_info(log_file):
+        def get_ryujinx_info(log_file=log_file):
             try:
                 self.embed["emu_info"]["ryu_version"] = [
                     line.split()[-1]
@@ -201,7 +201,7 @@ class LogFileReader(Cog):
 
             return log_embed
 
-        def analyse_log(log_file):
+        def analyse_log(log_file=log_file):
             try:
                 self.embed["game_info"]["game_name"] = (
                     re.search(
@@ -215,7 +215,7 @@ class LogFileReader(Cog):
                 for setting_name in self.embed["settings"]:
                     # Some log info may be missing for users that use older versions of Ryujinx, so reading the settings is not always possible.
                     # As settings are initialized with "Unknown" values, False should not be an issue for setting.get()
-                    def get_setting(log_file, name, setting_string):
+                    def get_setting(name, setting_string, log_file=log_file):
                         setting = self.embed["settings"]
                         setting_value = [
                             line.split()[-1]
@@ -280,7 +280,7 @@ class LogFileReader(Cog):
                     }
                     try:
                         self.embed[setting_name] = get_setting(
-                            log_file, setting_name, setting_map[setting_name]
+                            setting_name, setting_map[setting_name], log_file=log_file
                         )
                     except (AttributeError, IndexError) as error:
                         print(
@@ -288,7 +288,7 @@ class LogFileReader(Cog):
                         )
                         continue
 
-                def analyse_error_message(log_file):
+                def analyse_error_message(log_file=log_file):
                     try:
                         errors = []
                         curr_error_lines = []
@@ -318,7 +318,7 @@ class LogFileReader(Cog):
 
                 # Finds the lastest error denoted by |E| in the log and its first line
                 # Also warns of shader cache collisions
-                last_error_snippet, shader_cache_warn = analyse_error_message(log_file)
+                last_error_snippet, shader_cache_warn = analyse_error_message()
                 if last_error_snippet:
                     self.embed["game_info"]["errors"] = f"```{last_error_snippet}```"
                 else:
@@ -334,7 +334,7 @@ class LogFileReader(Cog):
                     timestamp_message = f"ℹ️ Time elapsed in log: `{latest_timestamp}`"
                     self.embed["game_info"]["notes"].append(timestamp_message)
 
-                def mods_information(log_file):
+                def mods_information(log_file=log_file):
                     mods_regex = re.compile(r"Found mod\s\'(.+?)\'\s(\[.+?\])")
                     matches = re.findall(mods_regex, log_file)
                     if matches:
@@ -348,7 +348,7 @@ class LogFileReader(Cog):
                         return mods_status
 
                 # Find information on installed mods
-                game_mods = mods_information(log_file)
+                game_mods = mods_information()
                 if game_mods:
                     self.embed["game_info"]["mods"] = "\n".join(game_mods)
                 else:
@@ -424,9 +424,9 @@ class LogFileReader(Cog):
             except AttributeError:
                 pass
 
-        get_hardware_info(log_file)
-        get_ryujinx_info(log_file)
-        game_notes = analyse_log(log_file)
+        get_hardware_info()
+        get_ryujinx_info()
+        game_notes = analyse_log()
 
         return format_log_embed()
 

--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -157,7 +157,7 @@ class LogFileReader(Cog):
             )
             log_embed.add_field(
                 name="Notes",
-                value="\n".join([note for note in self.embed["game_info"]["notes"]]),
+                value="\n".join(game_notes),
                 inline=False,
             )
 
@@ -272,9 +272,20 @@ class LogFileReader(Cog):
                 log_string = "✅ Default logs enabled"
             self.embed["game_info"]["notes"].append(log_string)
 
+            def severity(log_note_string):
+                symbols = ["❌", "⚠️", "ℹ", "✅"]
+                return next(
+                    i for i, symbol in enumerate(symbols) if symbol in log_note_string
+                )
+
+            game_notes = [note for note in self.embed["game_info"]["notes"]]
+            ordered_game_notes = sorted(game_notes, key=severity)
+
+            return ordered_game_notes
+
         get_hardware_info(log_file)
         get_ryujinx_info(log_file)
-        analyse_log(log_file)
+        game_notes = analyse_log(log_file)
 
         return format_log_embed()
 
@@ -302,9 +313,9 @@ class LogFileReader(Cog):
                             self.uploaded_log_filenames.append(filename)
                             # Avoid duplicate log file analysis, at least temporarily; keep track of the last few filenames of uploaded logs
                             # this should help support channels not be flooded with too many log files
-                            self.uploaded_log_filenames = self.uploaded_log_filenames[
-                                -5:
-                            ]
+                            # fmt: off
+                            self.uploaded_log_filenames = self.uploaded_log_filenames[-5:]
+                            # fmt: on
                         return await reply_message.edit(content=None, embed=embed)
                     except UnicodeDecodeError:
                         return await message.channel.send(


### PR DESCRIPTION
This PR adds some log reading functions to the Ryuko bot. Upon uploading of a Ryujinx log file with the format `^Ryujinx_.*\.log$` the bot should be able to read the user's hardware info, operating system and the game name.

In addition, the bot will detect and show which mods are installed, as well as an errors present in the log. The errors shown will be a snippet only, starting from the last error in the log since those can indicate a crash.

If the user meets some criteria a warning will be shown. Currently, these are:

- Having any default logs turned off (Info, Warning, Error, Guest, Stub)
- Having less than 8GB RAM available
- Using macOS
- Using an Intel iGPU on (macOS or Windows)

Here are some previews:

![Screenshot 2021-03-05 162143](https://user-images.githubusercontent.com/36304206/110143245-f0b41200-7dce-11eb-98b7-7a92417ec7e7.png)
![Screenshot 2021-03-05 162251](https://user-images.githubusercontent.com/36304206/110143359-13dec180-7dcf-11eb-949b-ad16e4c9f774.png)
![Screenshot 2021-03-05 162402](https://user-images.githubusercontent.com/36304206/110143514-3a9cf800-7dcf-11eb-9804-2e28e0bb0a00.png)
![Screenshot 2021-03-05 162445](https://user-images.githubusercontent.com/36304206/110143615-50aab880-7dcf-11eb-9523-e3cd28e35c30.png)
![Screenshot 2021-03-05 162509](https://user-images.githubusercontent.com/36304206/110143658-5dc7a780-7dcf-11eb-978b-eb3643b505d9.png)

The bot now shows the user's controller configuration as well.

I have also implemented restrictions for log analysis to only happen in the #support and #patreon-support channels. Posting a log outside of these channels will show a message warning the user to do so only in those channels.
