### PR TITLE
Shows error snippet on empty log

### DIFF
--- a/cogs/logfilereader.py
+++ b/cogs/logfilereader.py
@@ -66,51 +66,71 @@ class LogFileReader(Cog):
         log_file = re.search(log_file_header_regex, log_file).group(0)
 
         def get_hardware_info(log_file=log_file):
-            try:
-                self.embed["hardware_info"]["cpu"] = (
-                    re.search(r"CPU:\s([^;\n\r]*)", log_file, re.MULTILINE)
-                    .group(1)
-                    .rstrip()
-                )
-                self.embed["hardware_info"]["ram"] = (
-                    re.search(r"RAM:(\sTotal)?\s([^;\n\r]*)", log_file, re.MULTILINE)
-                    .group(2)
-                    .rstrip()
-                )
-                self.embed["hardware_info"]["os"] = (
-                    re.search(r"Operating System:\s([^;\n\r]*)", log_file, re.MULTILINE)
-                    .group(1)
-                    .rstrip()
-                )
-                self.embed["hardware_info"]["gpu"] = (
-                    re.search(
-                        r"PrintGpuInformation:\s([^;\n\r]*)", log_file, re.MULTILINE
-                    )
-                    .group(1)
-                    .rstrip()
-                )
-            except AttributeError:
-                pass
+            for setting in self.embed["hardware_info"]:
+                try:
+                    if setting == "cpu":
+                        self.embed["hardware_info"][setting] = (
+                            re.search(r"CPU:\s([^;\n\r]*)", log_file, re.MULTILINE)
+                            .group(1)
+                            .rstrip()
+                        )
+                    if setting == "ram":
+                        self.embed["hardware_info"][setting] = (
+                            re.search(
+                                r"RAM:(\sTotal)?\s([^;\n\r]*)", log_file, re.MULTILINE
+                            )
+                            .group(2)
+                            .rstrip()
+                        )
+                    if setting == "os":
+                        self.embed["hardware_info"][setting] = (
+                            re.search(
+                                r"Operating System:\s([^;\n\r]*)",
+                                log_file,
+                                re.MULTILINE,
+                            )
+                            .group(1)
+                            .rstrip()
+                        )
+                    if setting == "gpu":
+                        self.embed["hardware_info"][setting] = (
+                            re.search(
+                                r"PrintGpuInformation:\s([^;\n\r]*)",
+                                log_file,
+                                re.MULTILINE,
+                            )
+                            .group(1)
+                            .rstrip()
+                        )
+                except AttributeError:
+                    continue
 
         def get_ryujinx_info(log_file=log_file):
-            try:
-                self.embed["emu_info"]["ryu_version"] = [
-                    line.split()[-1]
-                    for line in log_file.splitlines()
-                    if "Ryujinx Version:" in line
-                ][0]
-                self.embed["emu_info"]["logs_enabled"] = (
-                    re.search(r"Logs Enabled:\s([^;\n\r]*)", log_file, re.MULTILINE)
-                    .group(1)
-                    .rstrip()
-                )
-                self.embed["emu_info"]["ryu_firmware"] = [
-                    line.split()[-1]
-                    for line in log_file.splitlines()
-                    if "Firmware Version:" in line
-                ][0]
-            except (AttributeError, IndexError):
-                pass
+            # try:
+            for setting in self.embed["emu_info"]:
+                try:
+                    if setting == "ryu_version":
+                        self.embed["emu_info"][setting] = [
+                            line.split()[-1]
+                            for line in log_file.splitlines()
+                            if "Ryujinx Version:" in line
+                        ][0]
+                    if setting == "logs_enabled":
+                        self.embed["emu_info"][setting] = (
+                            re.search(
+                                r"Logs Enabled:\s([^;\n\r]*)", log_file, re.MULTILINE
+                            )
+                            .group(1)
+                            .rstrip()
+                        )
+                    if setting == "ryu_firmware":
+                        self.embed["emu_info"]["ryu_firmware"] = [
+                            line.split()[-1]
+                            for line in log_file.splitlines()
+                            if "Firmware Version:" in line
+                        ][0]
+                except (AttributeError, IndexError):
+                    continue
 
         def format_log_embed():
             cleaned_game_name = re.sub(


### PR DESCRIPTION
Ryujinx sometimes crashes before a game is loaded, this change allows the error snippet to be seen when that happens.

Shader cache corruption is also detected by reading: `"Object reference not set to an instance of an object. at Ryujinx.Graphics.Gpu.Shader.ShaderCache.Initialize()"`. A warning to investigate shows up.

![image](https://user-images.githubusercontent.com/36304206/121015463-eec56a80-c792-11eb-98e5-8ee7338165f5.png)
