### PR TITLE
Log reading improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ config.py
 
 # Prevent data files from being committed
 data/
+robocop_ng/config_template.py

--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -15,7 +15,6 @@ logging.basicConfig(
 class LogFileReader(Cog):
     def __init__(self, bot):
         self.bot = bot
-        # Allows log analysis in #support and #patreon-support channels respectively
         self.bot_log_allowed_channels = config.bot_log_allowed_channels
         self.ryujinx_blue = Colour(0x4A90E2)
         self.uploaded_log_info = []
@@ -357,9 +356,9 @@ class LogFileReader(Cog):
                         )
                         shader_cache_corruption = error_search(
                             [
-                                """Object reference not set to an instance of an object.
-                                                                at Ryujinx.Graphics.Gpu.Shader.ShaderCache.Initialize()""",
+                                "Ryujinx.Graphics.Gpu.Shader.ShaderCache.Initialize()",
                                 "System.IO.InvalidDataException: End of Central Directory record could not be found",
+                                "ICSharpCode.SharpZipLib.Zip.ZipException: Cannot find central directory",
                             ]
                         )
                         update_keys_error = error_search(["LibHac.MissingKeyException"])
@@ -488,7 +487,6 @@ class LogFileReader(Cog):
                         intel_gpu_warning = "**⚠️ Intel iGPUs are known to have driver issues, consider using a discrete GPU**"
                         self.embed["game_info"]["notes"].append(intel_gpu_warning)
                 try:
-                    # Find information on logs, whether defaults are enabled or not
                     default_logs = ["Info", "Warning", "Error", "Guest", "Stub"]
                     user_logs = (
                         self.embed["emu_info"]["logs_enabled"]
@@ -631,7 +629,6 @@ class LogFileReader(Cog):
                     True for elem in self.uploaded_log_info if filename in elem.values()
                 ]
                 if not any(uploaded_logs_exist):
-                    # if filename not in self.uploaded_log_info:
                     reply_message = await message.channel.send(
                         "Log detected, parsing..."
                     )

--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -235,15 +235,15 @@ class LogFileReader(Cog):
                     name="Mods", value=self.embed["game_info"]["mods"], inline=False
                 )
 
-                try:
-                    notes_value = "\n".join(game_notes)
-                except TypeError:
-                    notes_value = "Nothing to note"
-                log_embed.add_field(
-                    name="Notes",
-                    value=notes_value,
-                    inline=False,
-                )
+            try:
+                notes_value = "\n".join(game_notes)
+            except TypeError:
+                notes_value = "Nothing to note"
+            log_embed.add_field(
+                name="Notes",
+                value=notes_value,
+                inline=False,
+            )
 
             return log_embed
 

--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -442,7 +442,6 @@ class LogFileReader(Cog):
                         ]
                         return mods_status
 
-                # Find information on installed mods
                 game_mods = mods_information()
                 if game_mods:
                     self.embed["game_info"]["mods"] = "\n".join(game_mods)
@@ -457,9 +456,14 @@ class LogFileReader(Cog):
                     # also maintains the list order
                     input_status = list(dict.fromkeys(input_status))
                     input_string = "\n".join(input_status)
-                else:
+                    self.embed["game_info"]["notes"].append(input_string)
+                # If emulator crashes on startup without game load, there is no need to show controller notification at all
+                if (
+                    not controllers
+                    and self.embed["game_info"]["game_name"] != "Unknown"
+                ):
                     input_string = "⚠️ No controller information found"
-                self.embed["game_info"]["notes"].append(input_string)
+                    self.embed["game_info"]["notes"].append(input_string)
 
                 try:
                     ram_available_regex = re.compile(r"Available\s(\d+)(?=\sMB)")

--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -23,7 +23,7 @@ class LogFileReader(Cog):
     async def download_file(self, log_url):
         async with aiohttp.ClientSession() as session:
             # Grabs first and last few bytes of log file to prevent abuse from large files
-            headers = {"Range": "bytes=0-25000, -6000"}
+            headers = {"Range": "bytes=0-35000, -6000"}
             async with session.get(log_url, headers=headers) as response:
                 return await response.text("UTF-8")
 

--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -235,15 +235,15 @@ class LogFileReader(Cog):
                     name="Mods", value=self.embed["game_info"]["mods"], inline=False
                 )
 
-            try:
-                notes_value = "\n".join(game_notes)
-            except TypeError:
-                notes_value = "Nothing to note"
-            log_embed.add_field(
-                name="Notes",
-                value=notes_value,
-                inline=False,
-            )
+                try:
+                    notes_value = "\n".join(game_notes)
+                except TypeError:
+                    notes_value = "Nothing to note"
+                log_embed.add_field(
+                    name="Notes",
+                    value=notes_value,
+                    inline=False,
+                )
 
             return log_embed
 
@@ -349,7 +349,12 @@ class LogFileReader(Cog):
                             return False
 
                         shader_cache_collision = error_search(["Cache collision found"])
-                        dump_hash_warning = error_search(["ResultFsInvalidIvfcHash"])
+                        dump_hash_warning = error_search(
+                            [
+                                "ResultFsInvalidIvfcHash",
+                                "ResultFsNonRealDataVerificationFailed",
+                            ]
+                        )
                         shader_cache_corruption = error_search(
                             [
                                 """Object reference not set to an instance of an object.
@@ -414,7 +419,7 @@ class LogFileReader(Cog):
 
                 if update_keys_error:
                     update_keys_error = (
-                        f"⚠️ Keys or firmware out of date, consider updating them."
+                        f"⚠️ Keys or firmware out of date, consider updating them"
                     )
                     self.embed["game_info"]["notes"].append(update_keys_error)
 
@@ -542,6 +547,10 @@ class LogFileReader(Cog):
                         ignore_missing_services_warning
                     )
 
+                if self.embed["settings"]["vsync"] == "Disabled":
+                    vsync_warning = f"⚠️ V-Sync disabled can cause instability like games running faster than intended or longer load times"
+                    self.embed["game_info"]["notes"].append(vsync_warning)
+
                 mainline_version = re.compile(r"^\d\.\d\.(\d){4}$")
                 pr_version = re.compile(r"^\d\.\d\.\d\+([a-f]|\d){7}$")
                 ldn_version = re.compile(r"^\d\.\d\.\d\-ldn\d\.\d$")
@@ -648,7 +657,7 @@ class LogFileReader(Cog):
                         )
                     except Exception as error:
                         await reply_message.edit(
-                            content=f"Error: Couldn't parse log; parser threw {type(error).__name__} exception."
+                            content=f"Error: Couldn't parse log; parser threw `{type(error).__name__}` exception."
                         )
                         print(logging.warn(error))
                 else:

--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -48,7 +48,9 @@ class LogFileReader(Cog):
             "settings": {
                 "audio_backend": "Unknown",
                 "docked": "Unknown",
+                "expand_ram": "Unknown",
                 "ignore_missing_services": "Unknown",
+                "memory_manager": "Unknown",
                 "pptc": "Unknown",
                 "shader_cache": "Unknown",
                 "vsync": "Unknown",
@@ -276,7 +278,6 @@ class LogFileReader(Cog):
                                 }
                                 setting[name] = aspect_map[setting_value]
                             if name in [
-                                "ignore_missing_services",
                                 "pptc",
                                 "shader_cache",
                                 "vsync",
@@ -291,7 +292,9 @@ class LogFileReader(Cog):
                         "aspect_ratio": "AspectRatio",
                         "audio_backend": "AudioBackend",
                         "docked": "EnableDockedMode",
+                        "expand_ram": "ExpandRam",
                         "ignore_missing_services": "IgnoreMissingServices",
+                        "memory_manager": "MemoryManagerMode",
                         "pptc": "EnablePtc",
                         "resolution_scale": "ResScale",
                         "shader_cache": "EnableShaderCache",
@@ -469,6 +472,9 @@ class LogFileReader(Cog):
                         .replace(" ", "")
                         .split(",")
                     )
+                    if "Debug" in user_logs:
+                        debug_warning = f"⚠️ **Debug logs enabled will have a negative impact on performance**"
+                        self.embed["game_info"]["notes"].append(debug_warning)
                     disabled_logs = set(default_logs).difference(set(user_logs))
                     if disabled_logs:
                         logs_status = [
@@ -485,6 +491,12 @@ class LogFileReader(Cog):
                     firmware_warning = f"**❌ Nintendo Switch firmware not found**"
                     self.embed["game_info"]["notes"].append(firmware_warning)
 
+                if self.embed["settings"]["anisotropic_filtering"] != "Auto":
+                    anisotropic_filtering_warning = "⚠️ Anisotropic filtering not set to `Auto` can cause graphical issues"
+                    self.embed["game_info"]["notes"].append(
+                        anisotropic_filtering_warning
+                    )
+
                 if self.embed["settings"]["audio_backend"] == "Dummy":
                     dummy_warning = (
                         f"⚠️ Dummy audio backend, consider changing to SDL2 or OpenAL"
@@ -492,12 +504,28 @@ class LogFileReader(Cog):
                     self.embed["game_info"]["notes"].append(dummy_warning)
 
                 if self.embed["settings"]["pptc"] == "Disabled":
-                    pptc_warning = f"⚠️ PPTC cache should be enabled"
+                    pptc_warning = f"🔴 **PPTC cache should be enabled**"
                     self.embed["game_info"]["notes"].append(pptc_warning)
 
                 if self.embed["settings"]["shader_cache"] == "Disabled":
-                    shader_warning = f"⚠️ Shader cache should be enabled"
+                    shader_warning = f"🔴 **Shader cache should be enabled**"
                     self.embed["game_info"]["notes"].append(shader_warning)
+
+                if self.embed["settings"]["expand_ram"] == "True":
+                    expand_ram_warning = f"⚠️ `Expand DRAM size to 6GB` should only be enabled for 4K mods"
+                    self.embed["game_info"]["notes"].append(expand_ram_warning)
+
+                if self.embed["settings"]["memory_manager"] == "SoftwarePageTable":
+                    software_memory_manager_warning = "⚠️ `Software` setting in Memory Manager Mode will give slower performance than the default setting of `Host unchecked`"
+                    self.embed["game_info"]["notes"].append(
+                        software_memory_manager_warning
+                    )
+
+                if self.embed["settings"]["ignore_missing_services"] == "True":
+                    ignore_missing_services_warning = "⚠️ `Ignore Missing Services` being enabled can cause instability"
+                    self.embed["game_info"]["notes"].append(
+                        ignore_missing_services_warning
+                    )
 
                 mainline_version = re.compile(r"^\d\.\d\.(\d){4}$")
                 pr_version = re.compile(r"^\d\.\d\.\d\+([a-f]|\d){7}$")
@@ -528,7 +556,7 @@ class LogFileReader(Cog):
                         self.embed["game_info"]["notes"].append(custom_firmware_warning)
 
                 def severity(log_note_string):
-                    symbols = ["❌", "⚠️", "ℹ", "✅"]
+                    symbols = ["❌", "🔴", "⚠️", "ℹ", "✅"]
                     return next(
                         i
                         for i, symbol in enumerate(symbols)


### PR DESCRIPTION
Adds new warnings for commonly enabled settings that shouldn't be. Most notably:

- Expand DRAM hack enabled
- Memory Manager Mode set to Software instead of the default Host Unchecked
- Ignore Missing Services enabled
- Anisotropic Filtering set to not Auto
- Debug logs enabled
- New severity level for PPTC and Shader cache warnings, this sits above a warning but below a breaking change like running macOS or not having firmware.