### PR TITLE
Add hackwarn command

### DIFF
--- a/robocop_ng/cogs/mod.py
+++ b/robocop_ng/cogs/mod.py
@@ -675,7 +675,7 @@ class Mod(Cog):
             chan_msg += (
                 "Please add an explanation below. In the future"
                 ", it is recommended to use "
-                "`.warn <user> [reason]`."
+                "`.hackwarn <user> [reason]`."
             )
 
         chan_msg += f"\n🔗 __Jump__: <{ctx.message.jump_url}>"


### PR DESCRIPTION
This PR adds `hackwarn` as a mod command.

Currently we `hackban` people who leave to avoid getting warned, so I thought a `hackwarn` command might be useful for these situations.

We should probably discuss this first before we add this.

---

Depends on #19

~~(I'll rebase this after #19 has been reviewed)~~