### PR TITLE
logfilereader: Fix game name detection

### DIFF
--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -420,7 +420,7 @@ class LogFileReader(Cog):
                 try:
                     self.embed["game_info"]["game_name"] = (
                         re.search(
-                            r"Loader LoadNca: Application Loaded:\s([^;\n\r]*)",
+                            r"Loader [A-Za-z]*: Application Loaded:\s([^;\n\r]*)",
                             log_file,
                             re.MULTILINE,
                         )


### PR DESCRIPTION
This PR allows Ryuko to detect the game names of log files like this one: [Ryujinx_1.1.723_2023-04-19_01-41-46.log](https://github.com/Ryujinx/ryuko-ng/files/11274079/Ryujinx_1.1.723_2023-04-19_01-41-46.log)
