### PR TITLE
Add commands to block log analysis of specific TIDs

### DIFF
--- a/robocop_ng/__main__.py
+++ b/robocop_ng/__main__.py
@@ -55,6 +55,7 @@ wanted_jsons = [
     "data/invites.json",
     "data/macros.json",
     "data/persistent_roles.json",
+    "data/disabled_tids.json",
 ]
 
 for wanted_json_idx in range(len(wanted_jsons)):

--- a/robocop_ng/__main__.py
+++ b/robocop_ng/__main__.py
@@ -77,10 +77,10 @@ bot.state_dir = state_dir
 bot.wanted_jsons = wanted_jsons
 
 
-async def get_channel_safe(self, id):
-    res = self.get_channel(id)
+async def get_channel_safe(self, channel_id: int):
+    res = self.get_channel(channel_id)
     if res is None:
-        res = await self.fetch_channel(id)
+        res = await self.fetch_channel(channel_id)
 
     return res
 

--- a/robocop_ng/config_template.py
+++ b/robocop_ng/config_template.py
@@ -1,5 +1,5 @@
-import hashlib
 import datetime
+import hashlib
 
 # Basic bot config, insert your token here, update description if you want
 prefixes = [".", "!"]
@@ -69,6 +69,7 @@ named_roles = {
     "community": 420010997877833731,
     "hacker": 364508795038072833,
     "participant": 434353085926866946,
+    "pirate": 0,
 }
 
 # The bot manager and staff roles

--- a/robocop_ng/helpers/disabled_tids.py
+++ b/robocop_ng/helpers/disabled_tids.py
@@ -1,0 +1,48 @@
+import json
+import os
+
+
+def get_disabled_tids_path(bot) -> str:
+    return os.path.join(bot.state_dir, "data/disabled_tids.json")
+
+
+def is_tid_valid(tid: str) -> bool:
+    return len(tid) == 16 and tid.isalnum()
+
+
+def get_disabled_tids(bot) -> dict[str, str]:
+    if os.path.isfile(get_disabled_tids_path(bot)):
+        with open(get_disabled_tids_path(bot), "r") as f:
+            return json.load(f)
+    return {}
+
+
+def set_disabled_tids(bot, contents: dict[str, str]):
+    with open(get_disabled_tids_path(bot), "w") as f:
+        json.dump(contents, f)
+
+
+def is_tid_disabled(bot, tid: str) -> bool:
+    disabled_tids = get_disabled_tids(bot)
+    tid = tid.lower()
+    return tid in disabled_tids.keys()
+
+
+def add_disabled_tid(bot, tid: str, note="") -> bool:
+    disabled_tids = get_disabled_tids(bot)
+    tid = tid.lower()
+    if tid not in disabled_tids.keys():
+        disabled_tids[tid] = note
+        set_disabled_tids(bot, disabled_tids)
+        return True
+    return False
+
+
+def remove_disabled_tid(bot, tid: str) -> bool:
+    disabled_tids = get_disabled_tids(bot)
+    tid = tid.lower()
+    if tid in disabled_tids.keys():
+        del disabled_tids[tid]
+        set_disabled_tids(bot, disabled_tids)
+        return True
+    return False

--- a/robocop_ng/helpers/macros.py
+++ b/robocop_ng/helpers/macros.py
@@ -3,13 +3,13 @@ import os
 from typing import Optional, Union
 
 
-def get_crontab_path(bot):
+def get_macros_path(bot):
     return os.path.join(bot.state_dir, "data/macros.json")
 
 
 def get_macros_dict(bot) -> dict[str, dict[str, Union[list[str], str]]]:
-    if os.path.isfile(get_crontab_path(bot)):
-        with open(get_crontab_path(bot), "r") as f:
+    if os.path.isfile(get_macros_path(bot)):
+        with open(get_macros_path(bot), "r") as f:
             macros = json.load(f)
 
         # Migration code
@@ -31,7 +31,7 @@ def get_macros_dict(bot) -> dict[str, dict[str, Union[list[str], str]]]:
                         del new_macros["macros"][key]
                         duplicate_num += 1
 
-            set_macros(new_macros)
+            set_macros(bot, new_macros)
             return new_macros
 
         return macros
@@ -52,7 +52,7 @@ def is_macro_key_available(
 
 
 def set_macros(bot, contents: dict[str, dict[str, Union[list[str], str]]]):
-    with open(get_crontab_path(bot), "w") as f:
+    with open(get_macros_path(bot), "w") as f:
         json.dump(contents, f)
 
 


### PR DESCRIPTION
This PR adds a few commands to `logfilereader`, so specific TIDs can be blocked from analysis.

If Ryuko reads a log containing a blocked TID the user who uploaded the log will be warned and the pirate role will also be applied.

In addition logs of pirates also won't be analyzed anymore.

---

Note: These changes require the addition of the `pirate` role to `named_roles` in the config file.