### PR TITLE
Fix a few macro and logfilereader issues

### DIFF
--- a/robocop_ng/__main__.py
+++ b/robocop_ng/__main__.py
@@ -6,6 +6,7 @@ import sys
 import aiohttp
 import discord
 from discord.ext import commands
+from discord.ext.commands import CommandError, Context
 
 if len(sys.argv[1:]) != 1:
     sys.stderr.write("usage: <state_dir>")
@@ -133,12 +134,12 @@ async def on_command(ctx):
 
 
 @bot.event
-async def on_error(event_method, *args, **kwargs):
-    log.exception(f"Error on {event_method}:")
+async def on_error(event: str, *args, **kwargs):
+    log.exception(f"Error on {event}:")
 
 
 @bot.event
-async def on_command_error(ctx, error):
+async def on_command_error(ctx: Context, error: CommandError):
     error_text = str(error)
 
     err_msg = (
@@ -147,7 +148,7 @@ async def on_command_error(ctx, error):
         f"of type {type(error)}: {error_text}"
     )
 
-    log.error(err_msg)
+    log.exception(err_msg, error)
 
     if not isinstance(error, commands.CommandNotFound):
         err_msg = bot.escape_message(err_msg)
@@ -259,8 +260,8 @@ async def main():
         for cog in config.initial_cogs:
             try:
                 await bot.load_extension(cog)
-            except:
-                log.exception(f"Failed to load cog {cog}.")
+            except Exception as e:
+                log.exception(f"Failed to load cog {cog}:", e)
         await bot.start(config.token)
 
 

--- a/robocop_ng/cogs/macro.py
+++ b/robocop_ng/cogs/macro.py
@@ -127,13 +127,24 @@ class Macro(Cog):
 
     @commands.cooldown(3, 30, BucketType.channel)
     @commands.command(name="macros", aliases=["ml", "listmacros", "list_macros"])
-    async def list_macros(self, ctx: Context):
+    async def list_macros(self, ctx: Context, macros_only=False):
         macros = get_macros_dict(self.bot)
         if len(macros["macros"]) > 0:
-            macros = [f"- {key}\n" for key in sorted(macros["macros"].keys())]
             message = "📝 **Macros**:\n"
-            for macro_key in macros:
-                message += macro_key
+
+            for key in sorted(macros["macros"].keys()):
+                message += f"- {key}\n"
+                if not macros_only and key in macros["aliases"].keys():
+                    message += "  - __aliases__: "
+                    first_alias = True
+                    for alias in macros["aliases"][key]:
+                        if first_alias:
+                            message += alias
+                            first_alias = False
+                            continue
+                        message += f", {alias}"
+                    message += "\n"
+
             await ctx.send(message)
         else:
             await ctx.send("Couldn't find any macros.")

--- a/robocop_ng/helpers/macros.py
+++ b/robocop_ng/helpers/macros.py
@@ -85,6 +85,8 @@ def add_aliases(bot, key: str, aliases: list[str]) -> bool:
         for alias in aliases:
             alias = alias.lower()
             if is_macro_key_available(bot, alias, macros):
+                if key not in macros["aliases"].keys():
+                    macros["aliases"][key] = []
                 macros["aliases"][key].append(alias)
                 success = True
         if success:


### PR DESCRIPTION
This PR fixes two exception that would occur for `macro` or `logfilereader`:

- `KeyError`: When trying to add an alias for a `macro` the `aliases` dictionary would not contain an existing key for the name of the macro, so adding a new alias would fail with this error.
- `AttributeError`: When `logfilereader` tries to parse a log file it assumes the log file always contains timestamps (like this: `00:00:00.073`). It would try to extract all log messages by detecting them and doesn't check if any matches were found, which led to this issue.

Aside from that I tried to improve exception logging a tiny bit, although I'm not sure if that changes anything.
I also added the aliases of macros to the `list_macros` command, so everything is listed within one message, which helps to get a better overview.