### PR TITLE
logfilereader: Fix analysing every attachment

### DIFF
--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -25,8 +25,7 @@ class LogFileReader(Cog):
     @staticmethod
     def is_valid_log_name(attachment: Attachment) -> tuple[bool, bool]:
         filename = attachment.filename
-        # Any message over 2000 chars is uploaded as message.txt, so this is accounted for
-        ryujinx_log_file_regex = re.compile(r"^Ryujinx_.*\.log|message\.txt$")
+        ryujinx_log_file_regex = re.compile(r"^Ryujinx_.*\.log$")
         log_file = re.compile(r"^.*\.log|.*\.txt$")
         is_ryujinx_log_file = re.match(ryujinx_log_file_regex, filename) is not None
         is_log_file = re.match(log_file, filename) is not None

--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -898,12 +898,17 @@ class LogFileReader(Cog):
         for attachment in message.attachments:
             is_log_file, is_ryujinx_log_file = self.is_valid_log_name(attachment)
 
-            if is_log_file and is_ryujinx_log_file and message.channel.id in self.bot_log_allowed_channels.values():
+            if (
+                is_log_file
+                and is_ryujinx_log_file
+                and message.channel.id in self.bot_log_allowed_channels.values()
+            ):
                 return await self.analyse_log_message(
                     message, message.attachments.index(attachment)
                 )
             elif (
-                is_log_file and is_ryujinx_log_file
+                is_log_file
+                and is_ryujinx_log_file
                 and message.channel.id not in self.bot_log_allowed_channels.values()
             ):
                 return await message.author.send(

--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -832,19 +832,20 @@ class LogFileReader(Cog):
                     self.uploaded_log_info = self.uploaded_log_info[-5:]
                     # fmt: on
                 return await reply_message.edit(content=None, embed=embed)
-            except UnicodeDecodeError:
-                return await message.channel.send(
+            except UnicodeDecodeError as error:
+                await reply_message.edit(
                     content=author_mention,
                     embed=Embed(
                         description="This log file appears to be invalid. Please re-check and re-upload your log file.",
                         colour=self.ryujinx_blue,
                     ),
                 )
+                logging.warning(error)
             except Exception as error:
                 await reply_message.edit(
                     content=f"Error: Couldn't parse log; parser threw `{type(error).__name__}` exception."
                 )
-                print(logging.warning(error))
+                logging.warning(error)
         else:
             duplicate_log_file = next(
                 (
@@ -898,20 +899,12 @@ class LogFileReader(Cog):
         for attachment in message.attachments:
             is_log_file, is_ryujinx_log_file = self.is_valid_log_name(attachment)
 
-            if message.channel.id in self.bot_log_allowed_channels.values():
+            if is_log_file and is_ryujinx_log_file and message.channel.id in self.bot_log_allowed_channels.values():
                 return await self.analyse_log_message(
                     message, message.attachments.index(attachment)
                 )
-            elif is_log_file and not is_ryujinx_log_file:
-                return await message.channel.send(
-                    content=message.author.mention,
-                    embed=Embed(
-                        description=f"Your file does not match the Ryujinx log format. Please check your file.",
-                        colour=self.ryujinx_blue,
-                    ),
-                )
             elif (
-                is_log_file
+                is_log_file and is_ryujinx_log_file
                 and message.channel.id not in self.bot_log_allowed_channels.values()
             ):
                 return await message.author.send(


### PR DESCRIPTION
This PR stops Ryuko from analysing all sorts of attachments and not just log files.

I also removed analysis for `message.txt` files since they will almost always be incomplete and mods will tell the user to upload a full log anyway.