### PR TITLE
logfilereader: Add exception for homebrew applications

### DIFF
--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -64,7 +64,8 @@ class LogFileReader(Cog):
     @staticmethod
     def is_log_valid(log_file: str) -> bool:
         app_info = LogAnalyser.get_app_info(log_file)
-        if app_info is None:
+        is_homebrew = LogAnalyser.is_homebrew(log_file)
+        if app_info is None or is_homebrew:
             return True
         game_name, app_id, another_app_id, build_ids, main_ro_section = app_info
         if (

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -36,6 +36,10 @@ class LogAnalyser:
     _notes: list[str]
 
     @staticmethod
+    def is_homebrew(log_file: str) -> bool:
+        return re.search("LoadApplication: Loading as Homebrew", log_file) is not None
+
+    @staticmethod
     def get_main_ro_section(log_file: str) -> Optional[dict[str, str]]:
         ro_section_match = re.search(
             r"PrintRoSectionInfo: main:[\r\n]*(.*)", log_file, re.DOTALL


### PR DESCRIPTION
Homebrew applications are currently marked as modified logs, since for some reason the application id doesn't match with other occurrences in the log.

So this PR adds an exception to the detection of modified logs for homebrew applications.