### PR TITLE
Updated RAM regex to work with both MiB and GB units

### DIFF
--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -210,15 +210,20 @@ class LogAnalyser:
 
                 case "ram":
                     ram_match = re.search(
-                        r"RAM:\s(Total)?\s([^;\n\r]*)\s;\s(Available)?\s(\d+)",
+                        r"RAM: Total ([\d.]+) (MiB|GB) ; Available ([\d.]+) (MiB|GB)",
                         self._log_text,
                         re.MULTILINE,
                     )
-                    if ram_match is not None and ram_match.group(2) is not None:
-                        self._hardware_info[setting] = ram_match.group(2).rstrip()
-                        ram_available = ram_match.group(4).rstrip()
-                        if ram_available.isnumeric():
+                    if ram_match is not None:
+                        try:
+                            ram_available = float(ram_match.group(3))
+                            if ram_match.group(4) == "GB":
+                                ram_available *= 1024
+
+                            self._hardware_info[setting] = f"{ram_match.group(1)} {ram_match.group(2)}"
                             self._ram_available_mib = int(ram_available)
+                        except ValueError:
+                            pass  # ram_match.group(3) couldn't be parsed as a float. Ignore the error and carry on.
 
                 case "os":
                     os_match = re.search(


### PR DESCRIPTION
As per gdkchan's comment here: https://github.com/Ryujinx/Ryujinx/pull/4956#issuecomment-1575597785

This change should enable the bot to parse logs regardless of whether they use MiB or GB units for RAM.
I couldn't test the bot because I lack the infrastructure to do so. The changes are simple enough though.