### PR TITLE
Finally fix list_macros completely

### DIFF
--- a/robocop_ng/cogs/macro.py
+++ b/robocop_ng/cogs/macro.py
@@ -138,7 +138,7 @@ class Macro(Cog):
 
             for key in sorted(macros["macros"].keys()):
                 message = f"- {key}"
-                if not macros_only:
+                if not macros_only and key in macros["aliases"]:
                     for alias in macros["aliases"][key]:
                         message += f", {alias}"
                 macros_formatted.append(message)


### PR DESCRIPTION
This should solve the issue causing Ryuko to throw `KeyError`s when trying to add all aliases to the list as well.