### PR TITLE
Fix .dockerignore patterns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
-config.py
-__pycache__
+**/__pycache__/
+.git/
+.github/
+.gitignore
+.dockerignore
+
+**/config.py
+**/data/

--- a/.gitignore
+++ b/.gitignore
@@ -98,8 +98,7 @@ files/*
 *.ttf
 
 priv-*
-config.py
 
 # Prevent data files from being committed
 data/
-robocop_ng/config_template.py
+robocop_ng/config.py


### PR DESCRIPTION
For some reason they decided to not follow what `.gitignore` does, so we can't use the same patterns in both files.

This PR fixes the patterns in `.dockerignore` and removes the exclusion of `config_template.py` from `.gitignore`.

---

https://docs.docker.com/engine/reference/builder/#dockerignore-file