### PR TITLE
Fix usernames overriding command reply targets

### DIFF
--- a/robocop_ng/cogs/meme.py
+++ b/robocop_ng/cogs/meme.py
@@ -195,7 +195,7 @@ class Meme(Cog):
         if target is None and ctx.message.reference is None:
             await ctx.reply("https://tenor.com/view/bonk-gif-26414884")
         else:
-            if target is None:
+            if ctx.message.reference is not None:
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author

--- a/robocop_ng/cogs/mod.py
+++ b/robocop_ng/cogs/mod.py
@@ -45,7 +45,9 @@ class Mod(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
+                if target is not None:
+                    reason = str(target) + reason
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author
@@ -139,7 +141,9 @@ class Mod(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
+                if target is not None:
+                    reason = str(target) + reason
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author
@@ -209,7 +213,9 @@ class Mod(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
+                if target is not None:
+                    reason = str(target) + reason
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author
@@ -281,7 +287,9 @@ class Mod(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
+                if target is not None:
+                    reason = str(target) + reason
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author
@@ -539,7 +547,7 @@ class Mod(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author
@@ -578,7 +586,7 @@ class Mod(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author
@@ -624,7 +632,9 @@ class Mod(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
+                if target is not None:
+                    reason = str(target) + reason
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author
@@ -778,7 +788,7 @@ class Mod(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author

--- a/robocop_ng/cogs/mod_timed.py
+++ b/robocop_ng/cogs/mod_timed.py
@@ -31,7 +31,9 @@ class ModTimed(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
+                if target is not None:
+                    duration = str(target) + duration
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author
@@ -107,7 +109,9 @@ class ModTimed(Cog):
                 f"I'm sorry {ctx.author.mention}, I'm afraid I can't do that."
             )
         else:
-            if target is None:
+            if ctx.message.reference is not None:
+                if target is not None:
+                    duration = str(target) + duration
                 target = (
                     await ctx.channel.fetch_message(ctx.message.reference.message_id)
                 ).author


### PR DESCRIPTION
This is not a very good fix for this issue, but we can't properly fix this without migrating to slash commands.

So I guess we need to cleanup Ryuko soon and migrate to slash commands, we need to do that at some point anyway.