### PR TITLE
Allow analyze command to be executed by everyone

### DIFF
--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -4,7 +4,7 @@ import re
 import aiohttp
 from discord import Colour, Embed, Message, Attachment
 from discord.ext import commands
-from discord.ext.commands import Cog, Context
+from discord.ext.commands import Cog, Context, BucketType
 
 from robocop_ng.helpers.checks import check_if_staff
 from robocop_ng.helpers.disabled_ids import (
@@ -513,7 +513,7 @@ class LogFileReader(Cog):
                 ),
             )
 
-    @commands.check(check_if_staff)
+    @commands.cooldown(3, 30, BucketType.channel)
     @commands.command(
         aliases=["analyselog", "analyse_log", "analyze", "analyzelog", "analyze_log"]
     )


### PR DESCRIPTION
Instead of restricting the command to staff members, everyone should be able to invoke it.

As a small protection I added a restriction that this command can only be used 3 times every 30 seconds per channel.