### PR TITLE
Handle various file related issues

### DIFF
--- a/robocop_ng/__main__.py
+++ b/robocop_ng/__main__.py
@@ -63,6 +63,9 @@ for wanted_json_idx in range(len(wanted_jsons)):
     wanted_jsons[wanted_json_idx] = os.path.join(
         state_dir, wanted_jsons[wanted_json_idx]
     )
+    if not os.path.isfile(wanted_jsons[wanted_json_idx]):
+        with open(wanted_jsons[wanted_json_idx], "w") as file:
+            file.write("{}")
 
 intents = discord.Intents.all()
 intents.typing = False

--- a/robocop_ng/__main__.py
+++ b/robocop_ng/__main__.py
@@ -8,6 +8,8 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import CommandError, Context
 
+from robocop_ng.helpers.notifications import report_critical_error
+
 if len(sys.argv[1:]) != 1:
     sys.stderr.write("usage: <state_dir>")
     sys.exit(1)
@@ -139,6 +141,25 @@ async def on_command(ctx):
 @bot.event
 async def on_error(event: str, *args, **kwargs):
     log.exception(f"Error on {event}:")
+
+    exception = sys.exception()
+    is_report_allowed = any(
+        [
+            not isinstance(exception, x)
+            for x in [
+                discord.RateLimited,
+                discord.GatewayNotFound,
+                discord.InteractionResponded,
+                discord.LoginFailure,
+            ]
+        ]
+    )
+    if exception is not None and is_report_allowed:
+        await report_critical_error(
+            bot,
+            exception,
+            additional_info={"Event": event, "args": args, "kwargs": kwargs},
+        )
 
 
 @bot.event

--- a/robocop_ng/helpers/macros.py
+++ b/robocop_ng/helpers/macros.py
@@ -2,6 +2,8 @@ import json
 import os
 from typing import Optional, Union
 
+from robocop_ng.helpers.notifications import report_critical_error
+
 
 def get_macros_path(bot):
     return os.path.join(bot.state_dir, "data/macros.json")
@@ -10,7 +12,18 @@ def get_macros_path(bot):
 def get_macros_dict(bot) -> dict[str, dict[str, Union[list[str], str]]]:
     if os.path.isfile(get_macros_path(bot)):
         with open(get_macros_path(bot), "r") as f:
-            macros = json.load(f)
+            try:
+                macros = json.load(f)
+            except json.JSONDecodeError as e:
+                content = f.read()
+                report_critical_error(
+                    bot,
+                    e,
+                    additional_info={
+                        "file": {"length": len(content), "content": content}
+                    },
+                )
+                return {}
 
         # Migration code
         if "aliases" not in macros.keys():

--- a/robocop_ng/helpers/notifications.py
+++ b/robocop_ng/helpers/notifications.py
@@ -1,0 +1,53 @@
+import json
+from typing import Optional, Union
+
+from discord import Message, MessageReference, PartialMessage
+
+
+MessageReferenceTypes = Union[Message, MessageReference, PartialMessage]
+
+
+async def notify_management(
+    bot, message: str, reference_message: Optional[MessageReferenceTypes] = None
+):
+    log_channel = await bot.get_channel_safe(bot.config.botlog_channel)
+    bot_manager_role = log_channel.guild.get_role(bot.config.bot_manager_role_id)
+
+    notification_message = f"{bot_manager_role.mention}:\n"
+
+    if reference_message is not None and reference_message.channel != log_channel:
+        notification_message += f"Message reference: {reference_message.jump_url}\n"
+        notification_message += message
+
+        return await log_channel.send(notification_message)
+    else:
+        notification_message += message
+
+        return await log_channel.send(
+            notification_message,
+            reference=reference_message,
+            mention_author=False,
+        )
+
+
+async def report_critical_error(
+    bot,
+    error: BaseException,
+    reference_message: Optional[MessageReferenceTypes] = None,
+    additional_info: Optional[dict] = None,
+):
+    message = "⛔ A critical error occurred!"
+
+    if additional_info is not None:
+        message += f"""
+            ```json
+            {json.dumps(additional_info)}
+            ```"""
+
+    message += f"""
+        Exception:
+        ```
+        {error}
+        ```"""
+
+    return await notify_management(bot, message, reference_message)

--- a/robocop_ng/helpers/robocronp.py
+++ b/robocop_ng/helpers/robocronp.py
@@ -2,14 +2,28 @@ import json
 import math
 import os
 
+from robocop_ng.helpers.notifications import report_critical_error
+
 
 def get_crontab_path(bot):
     return os.path.join(bot.state_dir, "data/robocronptab.json")
 
 
 def get_crontab(bot):
-    with open(get_crontab_path(bot), "r") as f:
-        return json.load(f)
+    if os.path.isfile(get_crontab_path(bot)):
+        with open(get_crontab_path(bot), "r") as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError as e:
+                content = f.read()
+                report_critical_error(
+                    bot,
+                    e,
+                    additional_info={
+                        "file": {"length": len(content), "content": content}
+                    },
+                )
+    return {}
 
 
 def set_crontab(bot, contents):

--- a/robocop_ng/helpers/roles.py
+++ b/robocop_ng/helpers/roles.py
@@ -2,6 +2,8 @@ import json
 import os.path
 import os
 
+from robocop_ng.helpers.notifications import report_critical_error
+
 
 def get_persistent_roles_path(bot):
     return os.path.join(bot.state_dir, "data/persistent_roles.json")
@@ -10,7 +12,17 @@ def get_persistent_roles_path(bot):
 def get_persistent_roles(bot) -> dict[str, list[str]]:
     if os.path.isfile(get_persistent_roles_path(bot)):
         with open(get_persistent_roles_path(bot), "r") as f:
-            return json.load(f)
+            try:
+                return json.load(f)
+            except json.JSONDecodeError as e:
+                content = f.read()
+                report_critical_error(
+                    bot,
+                    e,
+                    additional_info={
+                        "file": {"length": len(content), "content": content}
+                    },
+                )
     return {}
 
 

--- a/robocop_ng/helpers/userlogs.py
+++ b/robocop_ng/helpers/userlogs.py
@@ -2,6 +2,8 @@ import json
 import os
 import time
 
+from robocop_ng.helpers.notifications import report_critical_error
+
 userlog_event_types = {
     "warns": "Warn",
     "bans": "Ban",
@@ -16,8 +18,20 @@ def get_userlog_path(bot):
 
 
 def get_userlog(bot):
-    with open(get_userlog_path(bot), "r") as f:
-        return json.load(f)
+    if os.path.isfile(get_userlog_path(bot)):
+        with open(get_userlog_path(bot), "r") as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError as e:
+                content = f.read()
+                report_critical_error(
+                    bot,
+                    e,
+                    additional_info={
+                        "file": {"length": len(content), "content": content}
+                    },
+                )
+    return {}
 
 
 def set_userlog(bot, contents):


### PR DESCRIPTION
This PR adds a new helper file (`notifications.py`) which makes it easier to notify bot managers about issues.

This helper is used by the `on_error` handler, so we can react to issues faster.
The only exceptions it won't report are the ones that we can't act on or wouldn't be able to receive anyway.

Additionally handling for non-existent and empty files has been added for all the other helpers which make use of additional data files.