### PR TITLE
log_analyser: Fix homebrew detection

### DIFF
--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -37,7 +37,9 @@ class LogAnalyser:
 
     @staticmethod
     def is_homebrew(log_file: str) -> bool:
-        return re.search("LoadApplication: Loading as Homebrew", log_file) is not None
+        return (
+            re.search("Load.*Application: Loading as [Hh]omebrew", log_file) is not None
+        )
 
     @staticmethod
     def get_main_ro_section(log_file: str) -> Optional[dict[str, str]]:


### PR DESCRIPTION
Some logs are mistakenly marked as modified, because homebrew detection isn't working correctly.