### PR TITLE
logfilereader: Fix RAM parser issues

### DIFF
--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -6,7 +6,7 @@ from robocop_ng.helpers.disabled_ids import is_build_id_valid
 from robocop_ng.helpers.size import Size
 
 
-class CommonErrors(IntEnum):
+class CommonError(IntEnum):
     SHADER_CACHE_COLLISION = auto()
     DUMP_HASH = auto()
     SHADER_CACHE_CORRUPTION = auto()
@@ -502,36 +502,36 @@ class LogAnalyser:
     def __get_notes(self):
         for common_error in self.get_common_errors():
             match common_error:
-                case CommonErrors.SHADER_CACHE_COLLISION:
+                case CommonError.SHADER_CACHE_COLLISION:
                     self._notes.append(
                         "⚠️ Cache collision detected. Investigate possible shader cache issues"
                     )
-                case CommonErrors.SHADER_CACHE_CORRUPTION:
+                case CommonError.SHADER_CACHE_CORRUPTION:
                     self._notes.append(
                         "⚠️ Cache corruption detected. Investigate possible shader cache issues"
                     )
-                case CommonErrors.DUMP_HASH:
+                case CommonError.DUMP_HASH:
                     self._notes.append(
                         "⚠️ Dump error detected. Investigate possible bad game/firmware dump issues"
                     )
-                case CommonErrors.UPDATE_KEYS:
+                case CommonError.UPDATE_KEYS:
                     self._notes.append(
                         "⚠️ Keys or firmware out of date, consider updating them"
                     )
-                case CommonErrors.FILE_PERMISSIONS:
+                case CommonError.FILE_PERMISSIONS:
                     self._notes.append(
                         "⚠️ File permission error. Consider deleting save directory and allowing Ryujinx to make a new one"
                     )
-                case CommonErrors.FILE_NOT_FOUND:
+                case CommonError.FILE_NOT_FOUND:
                     self._notes.append(
                         "⚠️ Save not found error. Consider starting game without a save file or using a new save file⚠️ Save not found error. Consider starting game without a save file or using a new save file"
                     )
-                case CommonErrors.MISSING_SERVICES:
+                case CommonError.MISSING_SERVICES:
                     if self._settings["ignore_missing_services"] == "False":
                         self._notes.append(
                             "⚠️ Consider enabling `Ignore Missing Services` in Ryujinx settings"
                         )
-                case CommonErrors.VULKAN_OUT_OF_MEMORY:
+                case CommonError.VULKAN_OUT_OF_MEMORY:
                     if self._settings["texture_recompression"] == "Disabled":
                         self._notes.append(
                             "⚠️ Consider enabling `Texture Recompression` in Ryujinx settings"
@@ -593,11 +593,11 @@ class LogAnalyser:
     def get_last_error(self) -> Optional[list[str]]:
         return self._log_errors[-1] if len(self._log_errors) > 0 else None
 
-    def get_common_errors(self) -> list[CommonErrors]:
+    def get_common_errors(self) -> list[CommonError]:
         errors = []
 
         if self.contains_errors(["Cache collision found"], self._log_errors):
-            errors.append(CommonErrors.SHADER_CACHE_COLLISION)
+            errors.append(CommonError.SHADER_CACHE_COLLISION)
         if self.contains_errors(
             [
                 "ResultFsInvalidIvfcHash",
@@ -605,7 +605,7 @@ class LogAnalyser:
             ],
             self._log_errors,
         ):
-            errors.append(CommonErrors.DUMP_HASH)
+            errors.append(CommonError.DUMP_HASH)
         if self.contains_errors(
             [
                 "Ryujinx.Graphics.Gpu.Shader.ShaderCache.Initialize()",
@@ -614,17 +614,17 @@ class LogAnalyser:
             ],
             self._log_errors,
         ):
-            errors.append(CommonErrors.SHADER_CACHE_CORRUPTION)
+            errors.append(CommonError.SHADER_CACHE_CORRUPTION)
         if self.contains_errors(["MissingKeyException"], self._log_errors):
-            errors.append(CommonErrors.UPDATE_KEYS)
+            errors.append(CommonError.UPDATE_KEYS)
         if self.contains_errors(["ResultFsPermissionDenied"], self._log_errors):
-            errors.append(CommonErrors.FILE_PERMISSIONS)
+            errors.append(CommonError.FILE_PERMISSIONS)
         if self.contains_errors(["ResultFsTargetNotFound"], self._log_errors):
-            errors.append(CommonErrors.FILE_NOT_FOUND)
+            errors.append(CommonError.FILE_NOT_FOUND)
         if self.contains_errors(["ServiceNotImplementedException"], self._log_errors):
-            errors.append(CommonErrors.MISSING_SERVICES)
+            errors.append(CommonError.MISSING_SERVICES)
         if self.contains_errors(["ErrorOutOfDeviceMemory"], self._log_errors):
-            errors.append(CommonErrors.VULKAN_OUT_OF_MEMORY)
+            errors.append(CommonError.VULKAN_OUT_OF_MEMORY)
 
         return errors
 

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -221,10 +221,14 @@ class LogAnalyser:
                             dest_unit = Size.MiB
 
                             ram_available = float(ram_match.group(3))
-                            ram_available = Size.from_name(ram_match.group(4)).convert(ram_available, dest_unit)
+                            ram_available = Size.from_name(ram_match.group(4)).convert(
+                                ram_available, dest_unit
+                            )
 
                             ram_total = float(ram_match.group(1))
-                            ram_total = Size.from_name(ram_match.group(2)).convert(ram_total, dest_unit)
+                            ram_total = Size.from_name(ram_match.group(2)).convert(
+                                ram_total, dest_unit
+                            )
 
                             self._hardware_info[
                                 setting

--- a/robocop_ng/helpers/size.py
+++ b/robocop_ng/helpers/size.py
@@ -1,0 +1,49 @@
+from enum import IntEnum, auto
+from typing import Self
+
+
+class Size(IntEnum):
+    KB = auto()
+    KiB = auto()
+    MB = auto()
+    MiB = auto()
+    GB = auto()
+    GiB = auto()
+
+    @classmethod
+    def names(cls) -> list[str]:
+        return [size.name for size in cls]
+
+    @classmethod
+    def from_name(cls, name: str) -> Self:
+        for size in cls:
+            if size.name.lower() == name.lower():
+                return size
+        raise ValueError(f"No matching member found for: {name}")
+
+    @property
+    def _is_si_unit(self) -> bool:
+        return self.value % 2 != 0
+
+    @property
+    def _unit_value(self) -> int:
+        return self.value // 2 + (1 if self._is_si_unit else 0)
+
+    @property
+    def _base_factor(self) -> int:
+        return 10**3 if self._is_si_unit else 2**10
+
+    @property
+    def _byte_factor(self) -> int:
+        return 10**(3 * self._unit_value) if self._is_si_unit else 2 ** (10 * self._unit_value)
+
+    def convert(self, value: float, fmt: Self) -> float:
+        if self == fmt:
+            return value
+        if self._is_si_unit == fmt._is_si_unit:
+            if self < fmt:
+                return value / self._base_factor**(fmt._unit_value - self._unit_value)
+            else:
+                return value * self._base_factor**(self._unit_value - fmt._unit_value)
+        else:
+            return value * (self._byte_factor / fmt._byte_factor)

--- a/robocop_ng/helpers/size.py
+++ b/robocop_ng/helpers/size.py
@@ -35,15 +35,19 @@ class Size(IntEnum):
 
     @property
     def _byte_factor(self) -> int:
-        return 10**(3 * self._unit_value) if self._is_si_unit else 2 ** (10 * self._unit_value)
+        return (
+            10 ** (3 * self._unit_value)
+            if self._is_si_unit
+            else 2 ** (10 * self._unit_value)
+        )
 
     def convert(self, value: float, fmt: Self) -> float:
         if self == fmt:
             return value
         if self._is_si_unit == fmt._is_si_unit:
             if self < fmt:
-                return value / self._base_factor**(fmt._unit_value - self._unit_value)
+                return value / self._base_factor ** (fmt._unit_value - self._unit_value)
             else:
-                return value * self._base_factor**(self._unit_value - fmt._unit_value)
+                return value * self._base_factor ** (self._unit_value - fmt._unit_value)
         else:
             return value * (self._byte_factor / fmt._byte_factor)


### PR DESCRIPTION
With https://github.com/Ryujinx/Ryujinx/commit/623604c39186901fd64c8e04e9aa959d5c825529 we changed the unit for available and total RAM in the log again, but forgot to adjust Ryuko accordingly.

The PR author did adjust Ryuko for their change to GB (see: #58), but since we changed that before merging the Ryujinx PR this didn't work anymore.

Now this PR changes the way we deal with different size units in `logfilereader` by introducing a simple helper enum `Size`.
It allows us to easily convert from any unit to another and by adding it to the RAM parser, we can make sure we get the parsed value in the desired unit for every possible unit that could be used in a log file.

The result of the size conversion to our target unit might contain a lot of digits, which is why I cut off the fraction in the end. It shouldn't matter for quickly diagnosing issues to have the exact or rounded value, but if you want me to change this please tell me to do so.