### PR TITLE
Add hypervisor in Logfile outputs

### DIFF
--- a/robocop_ng/cogs/logfilereader.py
+++ b/robocop_ng/cogs/logfilereader.py
@@ -144,6 +144,7 @@ class LogFileReader(Cog):
                 f"**PPTC Cache:** `{analysed_log['settings']['pptc']}`",
                 f"**Shader Cache:** `{analysed_log['settings']['shader_cache']}`",
                 f"**V-Sync:** `{analysed_log['settings']['vsync']}`",
+                f"**Hypervisor:** `{analysed_log['settings']['hypervisor']}`",
             )
         )
 

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -135,8 +135,8 @@ class LogAnalyser:
             raise ValueError("No log entries found.")
 
         self.__get_errors()
-        self.__get_settings_info()
         self.__get_hardware_info()
+        self.__get_settings_info()
         self.__get_ryujinx_info()
         self.__get_app_name()
         self.__get_mods()
@@ -339,9 +339,14 @@ class LogAnalyser:
                 else:
                     return "Unknown"
 
-            case "pptc" | "shader_cache" | "texture_recompression" | "vsync" | "hypervisor":
+            case "pptc" | "shader_cache" | "texture_recompression" | "vsync":
                 return "Enabled" if value == "True" else "Disabled"
 
+            case "hypervisor":
+                if "mac" in self._hardware_info["os"]:
+                    return "Enabled" if value == "True" else "Disabled"
+                else:
+                    return "Not Applicable"
             case _:
                 return value
 
@@ -427,13 +432,6 @@ class LogAnalyser:
             if "AMD" in self._hardware_info["gpu"]:
                 self._notes.add(
                     "**⚠️ AMD GPU users should consider using Vulkan graphics backend**"
-                )
-        if (
-            "mac" in self._hardware_info["os"]
-        ):
-            if self._settings["hypervisor"] != "Enabled":
-                self._notes.add(
-                    "**⚠️ Hypervisor disabled, consider changing to Enabled.**"
                 )
 
     def __get_log_notes(self):

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -429,12 +429,12 @@ class LogAnalyser:
                     "**⚠️ AMD GPU users should consider using Vulkan graphics backend**"
                 )
         if (
-            "MacOS" in self.__hardware_info["os"]
-            and self.__settings["hypervisor"] != "Enabled"
+            "mac" in self._hardware_info["os"]
         ):
-            self.__notes.add(
-                "**⚠️ Hypervisor disabled, consider changing into Enabled.**"
-            )
+            if self._settings["hypervisor"] != "Enabled":
+                self._notes.add(
+                    "**⚠️ Hypervisor disabled, consider changing to Enabled.**"
+                )
 
     def __get_log_notes(self):
         default_logs = ["Info", "Warning", "Error", "Guest"]

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -177,6 +177,7 @@ class LogAnalyser:
             "anisotropic_filtering": "Unknown",
             "aspect_ratio": "Unknown",
             "texture_recompression": "Unknown",
+            "hypervisor": "Unknown",
         }
         self._notes = set()
         self._log_errors = []
@@ -338,7 +339,7 @@ class LogAnalyser:
                 else:
                     return "Unknown"
 
-            case "pptc" | "shader_cache" | "texture_recompression" | "vsync":
+            case "pptc" | "shader_cache" | "texture_recompression" | "vsync" | "hypervisor":
                 return "Enabled" if value == "True" else "Disabled"
 
             case _:
@@ -361,6 +362,7 @@ class LogAnalyser:
             "shader_cache": "EnableShaderCache",
             "texture_recompression": "EnableTextureRecompression",
             "vsync": "EnableVsync",
+            "hypervisor": "UseHypervisor",
         }
 
         for key in self._settings.keys():
@@ -426,6 +428,13 @@ class LogAnalyser:
                 self._notes.add(
                     "**⚠️ AMD GPU users should consider using Vulkan graphics backend**"
                 )
+        if (
+            "MacOS" in self.__hardware_info["os"]
+            and self.__settings["hypervisor"] != "Enabled"
+        ):
+            self.__notes.add(
+                "**⚠️ Hypervisor disabled, consider changing into Enabled.**"
+            )
 
     def __get_log_notes(self):
         default_logs = ["Info", "Warning", "Error", "Guest"]

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -346,7 +346,7 @@ class LogAnalyser:
                 if "mac" in self._hardware_info["os"]:
                     return "Enabled" if value == "True" else "Disabled"
                 else:
-                    return "Not Applicable"
+                    return "N/A"
             case _:
                 return value
 

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -173,11 +173,11 @@ class LogAnalyser:
             "pptc": "Unknown",
             "shader_cache": "Unknown",
             "vsync": "Unknown",
+            "hypervisor": "Unknown",
             "resolution_scale": "Unknown",
             "anisotropic_filtering": "Unknown",
             "aspect_ratio": "Unknown",
             "texture_recompression": "Unknown",
-            "hypervisor": "Unknown",
         }
         self._notes = set()
         self._log_errors = []


### PR DESCRIPTION
Easier checking for hypervisor status in macOS logfiles without opening the logfile itself.

- [x] Adds Hypervisor to logfile returns
- [x] If in macOS -> Enabled / Disabled | If not in macOS -> not Applicable