### PR TITLE
Simple fix for time elapsed

### DIFF
--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -543,7 +543,7 @@ class LogAnalyser:
                 case _:
                     raise NotImplementedError(common_error)
 
-        timestamp_regex = re.compile(r"\d{2}:\d{2}:\d{2}\.\d{3}")
+        timestamp_regex = re.compile(r"(\d{2}:\d{2}:\d{2}\.\d{3})\s+?\|")
         latest_timestamp = re.findall(timestamp_regex, self._log_text)[-1]
         if latest_timestamp:
             timestamp_message = f"ℹ️ Time elapsed: `{latest_timestamp}`"


### PR DESCRIPTION
Just trying to make the `ℹ️ Time elapsed` report the correct value, e.g.
```
00:00:00.074 |N| Application PrintSystemInfo: Launch Mode: UserProfile
00:00:01.754 |E| .NET TP Worker 2024-04-03 11:50:08.777 Ryujinx[2065:56231] WARNING: Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES.
```
should report `00:00:01.754` instead of `11:50:08.777`.