### PR TITLE
vanity_url: Fix crash when editing a guild

### DIFF
--- a/robocop_ng/cogs/vanity_url.py
+++ b/robocop_ng/cogs/vanity_url.py
@@ -1,4 +1,5 @@
 from discord import Guild
+from discord.errors import Forbidden
 from discord.ext import tasks
 from discord.ext.commands import Cog
 
@@ -14,9 +15,14 @@ class VanityUrl(Cog):
 
     async def update_vanity_code(self, guild: Guild, code: str):
         if "VANITY_URL" in guild.features and guild.vanity_url_code != code:
-            await guild.edit(
-                reason="Configured vanity code was different", vanity_code=code
-            )
+            try:
+                await guild.edit(
+                    reason="Configured vanity code was different", vanity_code=code
+                )
+            except Forbidden:
+                self.bot.log.exception(f"Not allowed to edit vanity url for: {guild}")
+                self.cog_unload()
+                await self.bot.unload_extension("robocop_ng.cogs.vanity_url")
 
     @Cog.listener()
     async def on_guild_update(self, before: Guild, after: Guild):

--- a/robocop_ng/config_template.py
+++ b/robocop_ng/config_template.py
@@ -38,7 +38,6 @@ initial_cogs = [
     "cogs.links",
     "cogs.remind",
     "cogs.robocronp",
-    "cogs.vanity_url",
     "cogs.meme",
     "cogs.invites",
     "cogs.yubicootp",


### PR DESCRIPTION
Apparently bots are not allowed to edit vanity urls, so this PR fixes the crash when that occurs when it tries to do so.

```
[2024-04-12 15:04:19,484] {__init__.py:537} ERROR - Unhandled exception in internal background task 'check_changed_vanity_codes'.
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/discord/ext/tasks/__init__.py", line 239, in _loop
    await self.coro(*args, **kwargs)
  File "/usr/src/app/robocop_ng/cogs/vanity_url.py", line 30, in check_changed_vanity_codes
    await self.update_vanity_code(self.bot.get_guild(guild), vanity_code)
  File "/usr/src/app/robocop_ng/cogs/vanity_url.py", line 17, in update_vanity_code
    await guild.edit(
  File "/usr/local/lib/python3.11/site-packages/discord/guild.py", line 1990, in edit
    await http.change_vanity_code(self.id, vanity_code, reason=reason)
  File "/usr/local/lib/python3.11/site-packages/discord/http.py", line 739, in request
    raise Forbidden(response, data)
discord.errors.Forbidden: 403 Forbidden (error code: 20001): Bots cannot use this endpoint
```

I also removed this cog from the config template, since there is currently no point in running it.

However should the cog be loaded and the exception occurs, it will unload itself now.