### PR TITLE
log_analyzer: Fix cheat detection

### DIFF
--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -397,7 +397,10 @@ class LogAnalyser:
             self._game_info["mods"] = "\n".join(mods_status)
 
     def __get_cheats(self):
-        cheat_regex = re.compile(r"Tampering program\s<(.+)>")
+        # Make sure to skip cheats which fail to compile
+        cheat_regex = re.compile(
+            r"Installing cheat\s'(.+)'(?!\s\d{2}:\d{2}:\d{2}\.\d{3}\s\|E\|\sTamperMachine\sCompile)"
+        )
         matches = re.findall(cheat_regex, self._log_text)
         if matches:
             cheats = [f"ℹ️ {match}" for match in matches]


### PR DESCRIPTION
This PR fixes the broken cheat detection in the log analyzer.
The new regex string also makes sure that we aren't matching cheats which fail to compile and can't be activated as a result.

---

Fixes #89