### PR TITLE
Add Note for Rosetta

### DIFF
--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -443,6 +443,12 @@ class LogAnalyser:
                     "**⚠️ AMD GPU users should consider using Vulkan graphics backend**"
                 )
 
+    def __get_cpu_notes(self):
+        if "Virtual Apple" in self._hardware_info["cpu"]:
+                self._notes.add(
+                    "🔴 **Rosetta should be disabled**"
+                )
+
     def __get_log_notes(self):
         default_logs = ["Info", "Warning", "Error", "Guest"]
         user_logs = []
@@ -572,6 +578,7 @@ class LogAnalyser:
 
         self.__get_controller_notes()
         self.__get_os_notes()
+        self.__get_cpu_notes()
 
         if (
             self._emu_info["ryu_firmware"] == "Unknown"

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -445,9 +445,7 @@ class LogAnalyser:
 
     def __get_cpu_notes(self):
         if "VirtualApple" in self._hardware_info["cpu"]:
-                self._notes.add(
-                    "🔴 **Rosetta should be disabled**"
-                )
+            self._notes.add("🔴 **Rosetta should be disabled**")
 
     def __get_log_notes(self):
         default_logs = ["Info", "Warning", "Error", "Guest"]

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -444,7 +444,7 @@ class LogAnalyser:
                 )
 
     def __get_cpu_notes(self):
-        if "Virtual Apple" in self._hardware_info["cpu"]:
+        if "VirtualApple" in self._hardware_info["cpu"]:
                 self._notes.add(
                     "🔴 **Rosetta should be disabled**"
                 )


### PR DESCRIPTION
Adds a note to parsed logs if `VirtualApple` is detected in the CPU field because Rosetta 2 is enabled.

Copied from code around it, I have not spun up a ryuko instance to test.