### PR TITLE
Fix broken build id regex & Return a set from get_filepaths

### DIFF
--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -88,7 +88,7 @@ class LogAnalyser:
             else:
                 app_id = ""
             bids_match_all = re.findall(
-                r"Build ids found for title ([a-zA-Z0-9]*):[\n\r]*((?:\s+.*[\n\r]+)+)",
+                r"Build ids found for (?:title|application) ([a-zA-Z0-9]*):[\n\r]*((?:\s+.*[\n\r]+)+)",
                 log_file,
             )
             if bids_match_all and len(bids_match_all) > 0:

--- a/robocop_ng/helpers/ryujinx_log_analyser.py
+++ b/robocop_ng/helpers/ryujinx_log_analyser.py
@@ -42,11 +42,11 @@ class LogAnalyser:
         )
 
     @staticmethod
-    def get_filepaths(log_file: str) -> list[str]:
-        return [
+    def get_filepaths(log_file: str) -> set[str]:
+        return set(
             x.rstrip("\u0000")
             for x in re.findall(r"(?:[A-Za-z]:)?(?:[\\/]+[^\\/:\"\r\n]+)+", log_file)
-        ]
+        )
 
     @staticmethod
     def get_main_ro_section(log_file: str) -> Optional[dict[str, str]]:
@@ -718,7 +718,7 @@ class LogAnalyser:
             "errors": self._log_errors,
             "settings": self._settings,
             "app_info": self.get_app_info(self._log_text),
-            "paths": self.get_filepaths(self._log_text),
+            "paths": list(self.get_filepaths(self._log_text)),
         }
 
 


### PR DESCRIPTION
Quick PR to fix an issue with the log analyser which prevents Ryuko from finding the build IDs in a log.